### PR TITLE
Add stars to user resource and remove stars route

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -564,18 +564,6 @@ type Data = (
     })[]
 ```
 
-# `/users/{userId}/stars`
-
-## `GET`
-
-Anyone can view anyone's stars
-
-### Response
-
-```ts
-type Data = string[]
-```
-
 # `/users/{userId}`
 
 ## `GET`
@@ -593,6 +581,7 @@ type Data = {
     isAdmin: boolean
     isVerified: boolean
   }
+  stars: string[]
 }
 ```
 
@@ -615,6 +604,7 @@ type Data = {
   username?: string
   firstName?: string
   lastName?: string
+  stars?: string[]
 }
 ```
 
@@ -658,6 +648,7 @@ type Data = {
   username: string
   firstName: string
   lastName: string
+  stars: string[]
 }
 ```
 
@@ -684,5 +675,6 @@ type Data = {
     isAdmin: boolean
     isVerified: boolean
   }
+  stars: string[]
 }[]
 ```

--- a/src/api.ts
+++ b/src/api.ts
@@ -296,6 +296,7 @@ interface UserInfo {
   firstName: string
   lastName: string
   roles: Roles
+  stars: string[]
 }
 
 interface EditableUser extends UserInfo {
@@ -314,9 +315,6 @@ export const getUsers = () => getRequest<UserInfo[]>(`users`)
 // Anyone can view any user
 export const getUser = (userId: number) =>
   getRequest<UserInfo>(`users/${userId}`)
-// Anyone can view anyone's stars
-export const getStarredEvents = (userId: number) =>
-  getRequest<string[]>(`users/${userId}/stars`)
 // Anyone can modify themselves
 // Only admins can modify other users
 export const modifyUser = (userId: number, user: Partial<EditableUser>) =>


### PR DESCRIPTION
```
Franklin Harding [9:05 PM]
I don't like the stars route

Caleb Eby [9:05 PM]
Oh?

Franklin Harding [9:05 PM]
It's just a part of the user resource
It should be on `/users` and `/users/{id}`

Caleb Eby [9:06 PM]
Can the frontend get the current user ID via the jwt?

Franklin Harding [9:06 PM]
Yes!

Caleb Eby [9:06 PM]
Without making a request

Franklin Harding [9:06 PM]
Yes!

Caleb Eby [9:06 PM]
Yes!

Franklin Harding [9:06 PM]
Because JWT rules

Caleb Eby [9:06 PM]
Ok docs PR, sgtm
```