### PR TITLE
Faster date formatting

### DIFF
--- a/src/components/match-card/index.tsx
+++ b/src/components/match-card/index.tsx
@@ -2,7 +2,7 @@ import { h } from 'preact'
 import { formatMatchKey } from '@/utils/format-match-key'
 import { formatTime } from '@/utils/format-time'
 import { formatTeamNumber } from '@/utils/format-team-number'
-import Card, { CardProps } from '@/components/card'
+import Card from '@/components/card'
 
 import style from './style.css'
 

--- a/src/components/match-card/index.tsx
+++ b/src/components/match-card/index.tsx
@@ -6,7 +6,7 @@ import Card, { CardProps } from '@/components/card'
 
 import style from './style.css'
 
-type MatchCardProps = CardProps<{
+type MatchCardProps = {
   match: {
     key: string
     redAlliance: string[]
@@ -14,12 +14,13 @@ type MatchCardProps = CardProps<{
     time?: Date
   }
   key?: string | number
-}>
+  href?: string
+}
 
-export const MatchCard = ({ match, ...rest }: MatchCardProps) => {
+export const MatchCard = ({ match, href }: MatchCardProps) => {
   const matchName = formatMatchKey(match.key)
   return (
-    <Card class={style.matchCard} {...rest}>
+    <Card class={style.matchCard} href={href}>
       <div class={style.matchTitle}>
         {matchName.num ? <div>{matchName.group}</div> : matchName.group}
         {matchName.num && (

--- a/src/utils/format-time/index.test.ts
+++ b/src/utils/format-time/index.test.ts
@@ -2,8 +2,6 @@ import { formatTime } from '.'
 
 describe('formatTime', () => {
   it('works with a string', () => {
-    expect(
-      formatTime(new Date('2018-04-19T19:37:49Z'), 'America/Los_Angeles'),
-    ).toEqual('Thu 12:37 PM')
+    expect(formatTime(new Date('2018-04-19T19:37:49Z'))).toEqual('Thu 12:37 PM')
   })
 })

--- a/src/utils/format-time/index.test.ts
+++ b/src/utils/format-time/index.test.ts
@@ -2,6 +2,8 @@ import { formatTime } from '.'
 
 describe('formatTime', () => {
   it('works with a string', () => {
-    expect(formatTime(new Date('2018-04-19T19:37:49Z'))).toEqual('Thu 12:37 PM')
+    expect(formatTime(new Date('2018-04-19T19:37:49Z'))).toMatch(
+      /\w\w\w \d\d?:\d\d [PA]M/,
+    )
   })
 })

--- a/src/utils/format-time/index.ts
+++ b/src/utils/format-time/index.ts
@@ -1,7 +1,7 @@
-export const formatTime = (date: Date, timeZone?: string) =>
-  date.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: 'numeric',
-    weekday: 'short',
-    timeZone,
-  })
+const timeFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: 'numeric',
+  weekday: 'short',
+})
+
+export const formatTime = (date: Date) => timeFormatter.format(date)


### PR DESCRIPTION
Before: https://dev.peregrine.ga/events/2018pncmp
![screenshot](https://user-images.githubusercontent.com/13206945/52390117-8d1e5580-2a4b-11e9-96c0-62ab15da359a.png)


After: https://perf-faster-date-formatting--peregrine.netlify.com/events/2018pncmp
![screenshot](https://user-images.githubusercontent.com/13206945/52390102-80016680-2a4b-11e9-870c-c2fc7a2aa3f3.png)


After it switches tabs much faster, you can test it