### PR TITLE
Make event sorting deterministic

### DIFF
--- a/src/utils/compare-events/index.ts
+++ b/src/utils/compare-events/index.ts
@@ -28,6 +28,10 @@ export const compareEvents = (a: PartialEvent, b: PartialEvent) => {
     return 1
   }
 
+  if (Number(a.startDate) === Number(b.startDate)) {
+    return a.name < b.name ? -1 : 1
+  }
+
   return Math.abs(now - Number(a.startDate)) <
     Math.abs(now - Number(b.startDate))
     ? -1


### PR DESCRIPTION
This fixes a bug I was seeing where on the first render it used the cached events, and then once it got the events from network it sorted them slightly differently (only for events with the same date). This fixes that