### PR TITLE
Fix analysis table for very wide screens

### DIFF
--- a/src/routes/event-analysis.tsx
+++ b/src/routes/event-analysis.tsx
@@ -15,6 +15,8 @@ interface Props {
 const analysisPageStyle = css`
   padding: 1rem;
   overflow: hidden;
+  display: flex;
+  justify-content: center;
 `
 
 const analysisTableStyle = css`


### PR DESCRIPTION
(This change is only visible on screens that are wider than the # of columns)

[The space on the right is bad](https://dev.peregrine.ga/events/2019orwil/analysis):
![screenshot](https://user-images.githubusercontent.com/13206945/61585699-575fbb80-ab17-11e9-9d20-7a69e01ef07c.png)
[I fixed it](https://fix-analysis-table-wide-screens--peregrine.netlify.com/events/2019orwil/analysis):
![screenshot](https://user-images.githubusercontent.com/13206945/61585704-5fb7f680-ab17-11e9-8a35-19619ca0ed4e.png)
