### PR TITLE
Fix sw console error

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -28,9 +28,7 @@ self.addEventListener('install', function(event) {
 
 const handleGETRequest = async (request: Request): Promise<Response> => {
   const cache = await cachePromise
-  const cacheResult = await cache.match(request)
-  if (!cacheResult) return fetch(request)
-  return cacheResult
+  return (await cache.match(request)) || fetch(request, { mode: 'same-origin' })
 }
 
 const handleFontsRequest = async (request: Request) => {


### PR DESCRIPTION
There was an error, saying that it wanted the same origin header. So I added it now there is no error

https://fix-sw-console-error--peregrine.netlify.com/