### PR TITLE
Fix event deletion from cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
       "plugin:caleb/jest"
     ],
     "rules": {
+      "no-return-await": "off",
       "caleb/react/display-name": "off",
       "no-else-return": [
         "error",

--- a/src/api/event-info/get-events.ts
+++ b/src/api/event-info/get-events.ts
@@ -2,11 +2,14 @@ import { request } from '../base'
 import { EventInfo, processEvent, ProcessedEventInfo } from '.'
 import { transaction } from '@/cache'
 import { requestIdleCallback } from '@/utils/request-idle-callback'
+import { idbPromise } from '@/utils/idb-promise'
 
 const updateCachedEvents = (events: ProcessedEventInfo[]) =>
   transaction(
     'events',
-    eventStore => {
+    async eventStore => {
+      // remove all existing events, in case any have been deleted
+      await idbPromise(eventStore.clear())
       events.forEach(event => eventStore.put(event, event.key))
     },
     'readwrite',

--- a/src/cache/events.ts
+++ b/src/cache/events.ts
@@ -5,6 +5,7 @@ import { getEventInfo } from '@/api/event-info/get-event-info'
 import { useNetworkCache } from '@/utils/use-network-cache'
 import { createPromiseRace } from '@/utils/fastest-promise'
 import { preventEmptyArrResolve } from '@/utils/prevent-empty-arr-resolve'
+import { preventUndefinedResolve } from '@/utils/prevent-undefined-resolve'
 
 const getCachedEvents = () =>
   transaction<ProcessedEventInfo[]>('events', eventStore =>
@@ -12,9 +13,9 @@ const getCachedEvents = () =>
   ).then(preventEmptyArrResolve)
 
 const getCachedEventInfo = (eventKey: string) =>
-  transaction<ProcessedEventInfo>('events', eventStore =>
+  transaction<ProcessedEventInfo | undefined>('events', eventStore =>
     eventStore.get(eventKey),
-  )
+  ).then(preventUndefinedResolve)
 
 export const getFastestEventInfo = createPromiseRace(
   getEventInfo,

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -41,9 +41,11 @@ export const transaction = async <ResolvedResult = void>(
   const tx = (await db).transaction(storeName, transactionType)
   const store = tx.objectStore(storeName)
   const handlerResult = await handler(store)
+  const data =
+    handlerResult instanceof IDBRequest
+      ? idbPromise(handlerResult)
+      : handlerResult
   // wait for transaction to finish
   await new Promise(resolve => (tx.oncomplete = resolve as () => {}))
-  return handlerResult instanceof IDBRequest
-    ? idbPromise(handlerResult)
-    : handlerResult
+  return data
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,3 +1,5 @@
+import { idbPromise } from '@/utils/idb-promise'
+
 const DB_NAME = 'CACHE'
 const DB_VERSION = 2
 
@@ -11,44 +13,36 @@ const initDB = (db: IDBDatabase) => {
     db.createObjectStore(MATCH_STORE)
 }
 
-const getDB = (dbName: string): Promise<IDBDatabase> =>
-  new Promise(resolve => {
-    const request = indexedDB.open(dbName, DB_VERSION)
-    request.addEventListener('upgradeneeded', () => initDB(request.result))
-    request.addEventListener('success', () => {
-      request.result.addEventListener('error', errorEvent => {
-        throw new Error(
-          ((errorEvent.target as unknown) as { error: string }).error,
-        )
-      })
-      resolve(request.result)
+const getDB = (dbName: string) => {
+  const request = indexedDB.open(dbName, DB_VERSION)
+  request.onupgradeneeded = () => initDB(request.result)
+  const requestPromise = idbPromise(request)
+  requestPromise.then(() => {
+    request.result.addEventListener('error', errorEvent => {
+      throw new Error(
+        ((errorEvent.target as unknown) as { error: string }).error,
+      )
     })
   })
+  return requestPromise
+}
 
 const db = getDB(DB_NAME)
 
-export const transaction = <ResolvedResult = void>(
+export const transaction = async <ResolvedResult = void>(
   storeName: string,
   handler: (
     store: IDBObjectStore,
-  ) => Promise<IDBRequest<ResolvedResult>> | IDBRequest<ResolvedResult> | void,
+  ) =>
+    | Promise<void | IDBRequest<ResolvedResult>>
+    | (void | IDBRequest<ResolvedResult>),
   transactionType: IDBTransactionMode = 'readonly',
-) =>
-  db.then(resolvedDb => {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise<ResolvedResult>(async resolve => {
-      const tx = resolvedDb.transaction(storeName, transactionType)
-      const store = tx.objectStore(storeName)
-      const handlerResult = await handler(store)
-      if (handlerResult) {
-        handlerResult.onsuccess = event => {
-          const { result } = (event.target as unknown) as {
-            result: ResolvedResult | undefined
-          }
-          if (result !== undefined) resolve(result)
-        }
-      } else {
-        tx.oncomplete = () => resolve()
-      }
-    })
-  })
+) => {
+  const tx = (await db).transaction(storeName, transactionType)
+  const store = tx.objectStore(storeName)
+  const handlerResult = await handler(store)
+  if (handlerResult) {
+    return idbPromise(handlerResult)
+  }
+  await new Promise(resolve => (tx.oncomplete = resolve))
+}

--- a/src/cache/matches.ts
+++ b/src/cache/matches.ts
@@ -6,13 +6,12 @@ import { getEventMatchInfo } from '@/api/match-info/get-event-match-info'
 import { createMatchDbKey } from '@/utils/create-match-db-key'
 import { preventEmptyArrResolve } from '@/utils/prevent-empty-arr-resolve'
 import { createPromiseRace } from '@/utils/fastest-promise'
+import { preventUndefinedResolve } from '@/utils/prevent-undefined-resolve'
 
 const getCachedEventMatches = (eventKey: string, team?: string) =>
-  transaction('matches', async matchStore => {
-    return matchStore.getAll(
-      IDBKeyRange.bound(`${eventKey}-`, `${eventKey}-z`),
-    ) as IDBRequest<ProcessedMatch[]>
-  })
+  transaction<ProcessedMatch[]>('matches', async matchStore =>
+    matchStore.getAll(IDBKeyRange.bound(`${eventKey}-`, `${eventKey}-z`)),
+  )
     .then(results =>
       team
         ? results.filter(
@@ -23,11 +22,9 @@ const getCachedEventMatches = (eventKey: string, team?: string) =>
     .then(preventEmptyArrResolve)
 
 const getCachedEventMatchInfo = (eventKey: string, matchKey: string) =>
-  transaction('matches', async matchStore => {
-    return matchStore.get(createMatchDbKey(eventKey, matchKey)) as IDBRequest<
-      ProcessedMatch
-    >
-  })
+  transaction<ProcessedMatch | undefined>('matches', async matchStore => {
+    return matchStore.get(createMatchDbKey(eventKey, matchKey))
+  }).then(preventUndefinedResolve)
 
 export const getFastestEventMatchInfo = createPromiseRace(
   getEventMatchInfo,

--- a/src/utils/empty-promise.ts
+++ b/src/utils/empty-promise.ts
@@ -1,0 +1,4 @@
+/**
+ * Promise that never resolves
+ */
+export const EMPTY_PROMISE = new Promise<never>(() => {})

--- a/src/utils/idb-promise.ts
+++ b/src/utils/idb-promise.ts
@@ -1,6 +1,7 @@
 export const idbPromise = <T>(request: IDBRequest<T>) =>
   new Promise<T>((resolve, reject) => {
     // eslint-disable-next-line caleb/unicorn/prefer-add-event-listener
-    request.onerror = () => reject(new Error(request.error))
+    request.onerror = () =>
+      reject(request.error && new Error(request.error.message))
     request.onsuccess = () => resolve(request.result)
   })

--- a/src/utils/idb-promise.ts
+++ b/src/utils/idb-promise.ts
@@ -1,0 +1,6 @@
+export const idbPromise = <T>(request: IDBRequest<T>) =>
+  new Promise<T>((resolve, reject) => {
+    // eslint-disable-next-line caleb/unicorn/prefer-add-event-listener
+    request.onerror = () => reject(new Error(request.error))
+    request.onsuccess = () => resolve(request.result)
+  })

--- a/src/utils/prevent-empty-arr-resolve.ts
+++ b/src/utils/prevent-empty-arr-resolve.ts
@@ -6,6 +6,8 @@ const EMPTY_PROMISE = new Promise<never>(() => {})
 /**
  * Prevents a promise from resolving if it resolves with an empty array
  * For use in a .then() callback
+ * @example
+ * foo().then(preventEmptyArrResolve)
  */
 export const preventEmptyArrResolve = <T extends any[]>(
   data: T,

--- a/src/utils/prevent-empty-arr-resolve.ts
+++ b/src/utils/prevent-empty-arr-resolve.ts
@@ -1,11 +1,8 @@
-/**
- * Promise that never resolves
- */
-const EMPTY_PROMISE = new Promise<never>(() => {})
+import { EMPTY_PROMISE } from './empty-promise'
 
 /**
- * Prevents a promise from resolving if it resolves with an empty array
- * For use in a .then() callback
+ * Prevents a promise from resolving if it resolves with an empty array.
+ * For use in a .then() callback.
  * @example
  * foo().then(preventEmptyArrResolve)
  */

--- a/src/utils/prevent-undefined-resolve.ts
+++ b/src/utils/prevent-undefined-resolve.ts
@@ -1,0 +1,11 @@
+import { EMPTY_PROMISE } from './empty-promise'
+
+/**
+ * Prevents a promise from resolving if it resolves with undefined.
+ * For use in a .then() callback.
+ * @example
+ * foo().then(preventUndefinedResolve)
+ */
+export const preventUndefinedResolve = <T>(
+  data: T | undefined,
+): T | Promise<T> => (data === undefined ? EMPTY_PROMISE : data)


### PR DESCRIPTION
Previously events that existed on TBA that were then deleted from TBA were sticking around in the indexeddb cache