### PR TITLE
Improve event sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /coverage
 /.linaria-cache
 *.css.json
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -4667,6 +4667,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "clsx": "1.0.4",
     "cpy": "7.3.0",
     "css-loader": "2.1.1",
+    "dotenv": "^8.0.0",
     "eslint": "6.1.0",
     "eslint-plugin-caleb": "5.0.0",
     "fake-indexeddb": "2.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,7 @@ import templite from 'templite'
 import sharp from 'sharp'
 import mkdirplz from 'mkdirplz'
 const postcssPlugins = require('./postcss.config').plugins
+require('dotenv').config()
 const babelConfig = require('./.babelrc')
 
 const writeFileAsync = promisify(writeFile)

--- a/src/api/event-info/index.ts
+++ b/src/api/event-info/index.ts
@@ -38,8 +38,10 @@ const parseDateInCurrentTZ = (str: string) => {
 
 export const processEvent = (e: EventInfo): ProcessedEventInfo => {
   const startDate = parseDateInCurrentTZ(e.startDate)
+  // Force it to beginning of the day
   startDate.setHours(0, 0, 0, 0)
   const endDate = parseDateInCurrentTZ(e.endDate)
+  // Force it to end of day, so the event is active for the whole day
   endDate.setHours(23, 59, 59, 999)
   return { ...e, startDate, endDate }
 }

--- a/src/api/event-info/index.ts
+++ b/src/api/event-info/index.ts
@@ -7,8 +7,8 @@ export interface EventInfo {
   // district "display_name" from TBA
   fullDistrict?: string
   locationName: string
-  lat: number
-  lon: number
+  lat?: number
+  lon?: number
   key: string
   // the ID of the realm the event belongs to
   realmId?: string
@@ -28,8 +28,18 @@ export type ProcessedEventInfo = Merge<
   { startDate: Date; endDate: Date }
 >
 
-export const processEvent = (e: EventInfo): ProcessedEventInfo => ({
-  ...e,
-  startDate: new Date(e.startDate),
-  endDate: new Date(e.endDate),
-})
+/** Offset from UTC in ms */
+const offset = new Date().getTimezoneOffset() * 60 * 1000
+
+const parseDateInCurrentTZ = (str: string) => {
+  const originalDate = new Date(str)
+  return new Date(originalDate.getTime() + offset)
+}
+
+export const processEvent = (e: EventInfo): ProcessedEventInfo => {
+  const startDate = parseDateInCurrentTZ(e.startDate)
+  startDate.setHours(0, 0, 0, 0)
+  const endDate = parseDateInCurrentTZ(e.endDate)
+  endDate.setHours(23, 59, 59, 999)
+  return { ...e, startDate, endDate }
+}

--- a/src/components/event-info-card.tsx
+++ b/src/components/event-info-card.tsx
@@ -54,14 +54,16 @@ export const EventInfoCard = ({ event }: Props) =>
   event ? (
     <InfoGroupCard
       info={[
-        event.locationName && {
-          icon: mapMarker,
-          title: event.locationName,
-          href: gmapsUrl(event.lat, event.lon),
-          target: '_blank',
-          rel: 'noopener',
-          action: <Icon icon={googleMaps} />,
-        },
+        event.locationName &&
+          event.lat &&
+          event.lon && {
+            icon: mapMarker,
+            title: event.locationName,
+            href: gmapsUrl(event.lat, event.lon),
+            target: '_blank',
+            rel: 'noopener',
+            action: <Icon icon={googleMaps} />,
+          },
         event.district && {
           icon: infoOutline,
           title: (

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -4,15 +4,19 @@ import EventCard from '@/components/event-card'
 import Spinner from '@/components/spinner'
 import { compareEvents } from '@/utils/compare-events'
 import { useEvents } from '@/cache/events'
+import { useGeoLocation } from '@/utils/use-geo-location'
+
+const now = new Date()
 
 const Home = () => {
   const events = useEvents()
+  const location = useGeoLocation()
   return (
     <Page name="Home" back={false}>
       <div>
         {events ? (
           events
-            .sort(compareEvents)
+            .sort(compareEvents(now, location))
             .map(e => (
               <EventCard href={`/events/${e.key}`} key={e.key} event={e} />
             ))

--- a/src/utils/compare-events/index.test.ts
+++ b/src/utils/compare-events/index.test.ts
@@ -1,65 +1,120 @@
-import { compareEvents, PartialEvent } from '.'
+import { compareEvents, PartialEvent, EventWithLocation } from '.'
+import { LatLong } from '../use-geo-location'
 
-test.each([
-  [
-    { startDate: new Date(100), endDate: new Date(200), name: 'foo' },
-    { startDate: new Date(300), endDate: new Date(350), name: 'bar' },
-    1,
-  ],
-  [
-    { startDate: new Date(300), endDate: new Date(325), name: 'foo' },
-    { startDate: new Date(100), endDate: new Date(120), name: 'bar' },
-    -1,
-  ],
-  [
-    {
-      startDate: new Date(Number(new Date()) + 1000),
-      endDate: new Date(Number(new Date()) + 1000),
-      name: 'foo',
-    },
-    { startDate: new Date(300), endDate: new Date(350), name: 'foo' },
-    -1,
-  ],
-  [
-    {
-      startDate: new Date(Number(new Date()) - 1000),
-      endDate: new Date(Number(new Date()) + 1000),
-      name: 'foo',
-    },
-    { startDate: new Date(300), endDate: new Date(350), name: 'foo' },
-    -1,
-  ],
-  [
-    {
-      startDate: new Date(Number(new Date()) + 2000),
-      endDate: new Date(Number(new Date()) + 3000),
-      name: 'foo',
-    },
-    {
-      startDate: new Date(Number(new Date()) + 1000),
-      endDate: new Date(Number(new Date()) + 2000),
-      name: 'foo',
-    },
-    1,
-  ],
-  [
-    {
-      startDate: new Date(Number(new Date()) + 2000),
-      endDate: new Date(Number(new Date()) + 3000),
-      name: 'foo',
-      week: 1,
-    },
-    {
-      startDate: new Date(Number(new Date()) + 1000),
-      endDate: new Date(Number(new Date()) + 2000),
-      name: 'bar',
-      week: 1,
-    },
-    1,
-  ],
-] as [PartialEvent, PartialEvent, 1 | -1][])(
-  'compare %s and %s',
-  (a, b, expected) => {
-    expect(Math.sign(compareEvents(a, b))).toEqual(expected)
-  },
-)
+const time = (num: number) => new Date(num)
+const now = time(0)
+const userLocation: LatLong = { latitude: 0, longitude: 0 }
+
+const currentNearbyEvent: EventWithLocation = {
+  name: 'Current Nearby',
+  startDate: time(-1),
+  endDate: time(3),
+  lat: 0.5,
+  lon: 0.5,
+}
+
+const currentFarEvent: EventWithLocation = {
+  name: 'Current Far a',
+  startDate: time(-3),
+  endDate: time(5),
+  lat: 2,
+  lon: 2,
+}
+
+const currentFarEvent2: EventWithLocation = {
+  name: 'Current Far b',
+  startDate: time(-3),
+  endDate: time(5),
+  lat: 2,
+  lon: 2,
+}
+
+const pastEvent: PartialEvent = {
+  name: 'Past',
+  startDate: time(-100),
+  endDate: time(-2),
+}
+
+const farPastEvent: PartialEvent = {
+  name: 'Far Past',
+  startDate: time(-300),
+  endDate: time(-301),
+}
+
+const futureEvent: PartialEvent = {
+  name: 'Future',
+  startDate: time(3),
+  endDate: time(5),
+}
+
+const futureOtherEvent: PartialEvent = {
+  name: 'Other equal future',
+  startDate: time(3),
+  endDate: time(5),
+}
+
+const farFutureEvent: PartialEvent = {
+  name: 'Far Future',
+  startDate: time(4),
+  endDate: time(5),
+}
+
+const expectOrder = (
+  a: PartialEvent,
+  b: PartialEvent,
+  comparer: (a: PartialEvent, b: PartialEvent) => number,
+) => {
+  let items: PartialEvent[] = []
+  try {
+    expect((items = [a, b]).sort(comparer)).toEqual([a, b])
+    expect((items = [b, a]).sort(comparer)).toEqual([a, b])
+  } catch (error) {
+    throw new Error(
+      `${items.map(i => i.name).join(', ')}
+
+Should have been sorted in this order:
+
+${[a.name, b.name].join(', ')}`,
+    )
+  }
+}
+
+test('two current events are sorted by location', () => {
+  expectOrder(
+    currentNearbyEvent,
+    currentFarEvent,
+    compareEvents(now, userLocation),
+  )
+})
+
+test('two current events are sorted by name if there is no location', () => {
+  expectOrder(currentFarEvent, currentNearbyEvent, compareEvents(now))
+})
+
+test('two current events are sorted by name if locations are equal', () => {
+  expectOrder(currentFarEvent, currentFarEvent2, compareEvents(now))
+})
+
+test('current events are before past events', () => {
+  expectOrder(currentFarEvent, pastEvent, compareEvents(now))
+})
+
+test('current events are before future events', () => {
+  expectOrder(currentFarEvent, futureEvent, compareEvents(now))
+})
+
+test('future events are before past events', () => {
+  expectOrder(futureEvent, pastEvent, compareEvents(now))
+})
+
+test('events with the same time get sorted by name', () => {
+  expectOrder(futureEvent, futureOtherEvent, compareEvents(now))
+})
+
+test('two future events are sorted by soonest start', () => {
+  expectOrder(futureEvent, farFutureEvent, compareEvents(now))
+})
+
+test('two past events are sorted by most recent end', () => {
+  expectOrder(pastEvent, farPastEvent, compareEvents(now))
+})

--- a/src/utils/distance-between-coordinates.ts
+++ b/src/utils/distance-between-coordinates.ts
@@ -1,0 +1,27 @@
+import { LatLong } from './use-geo-location'
+
+/** Earth's radius in meters */
+const R = 6371e3
+
+const toRadians = (deg: number) => deg * (Math.PI / 180)
+
+/**
+ * Distance between two points in meters
+ * @see http://www.movable-type.co.uk/scripts/latlong.html
+ */
+export const distanceBetweenCoordinates = (a: LatLong, b: LatLong) => {
+  const φ1 = toRadians(a.latitude)
+  const φ2 = toRadians(b.latitude)
+  const Δφ = toRadians(b.latitude - a.latitude)
+  const Δλ = toRadians(b.longitude - a.longitude)
+
+  /** Square of half chord length */
+  const e =
+    Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+    Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2)
+
+  /** Angular distance in radians */
+  const c = 2 * Math.atan2(Math.sqrt(e), Math.sqrt(1 - e))
+
+  return R * c
+}

--- a/src/utils/empty-promise.ts
+++ b/src/utils/empty-promise.ts
@@ -1,4 +1,5 @@
+export const noop = () => {}
 /**
  * Promise that never resolves
  */
-export const EMPTY_PROMISE = new Promise<never>(() => {})
+export const EMPTY_PROMISE = new Promise<never>(noop)

--- a/src/utils/use-geo-location.ts
+++ b/src/utils/use-geo-location.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'preact/hooks'
+import { EMPTY_PROMISE, noop } from './empty-promise'
+
+const apiKey = process.env.IPDATA_API_KEY
+const apiUrl =
+  apiKey && `https://api.ipdata.co/?api-key=${apiKey}&fields=latitude,longitude`
+
+export interface LatLong {
+  latitude: number
+  longitude: number
+}
+
+const getIpLocation = () =>
+  apiUrl
+    ? fetch(apiUrl)
+        .then(result => result.json())
+        .then(
+          (data): Promise<LatLong> =>
+            data.latitude && data.longitude ? data : EMPTY_PROMISE,
+        )
+    : EMPTY_PROMISE
+
+const getGeoLocation = () =>
+  new Promise<LatLong>(resolve =>
+    navigator.geolocation.getCurrentPosition(
+      result =>
+        resolve({
+          latitude: result.coords.latitude,
+          longitude: result.coords.longitude,
+        }),
+      // If there is an error, just use IP
+      () => resolve(getIpLocation()),
+    ),
+  )
+
+const getLocation = async (): Promise<LatLong> => {
+  if (navigator.permissions) {
+    const geoPermission = await navigator.permissions.query({
+      name: 'geolocation',
+    })
+    if (geoPermission.state === 'granted') return getGeoLocation()
+    // user has not granted location, so we will prompt for location after a certain amount of time
+    setTimeout(() => navigator.geolocation.getCurrentPosition(noop), 3 * 1000)
+  }
+  return getIpLocation()
+}
+
+const locationKey = 'geolocation'
+
+const getLocationFromLocalStorage = () => {
+  const result = localStorage.getItem(locationKey)
+  if (result) return JSON.parse(result) as LatLong
+}
+
+export const useGeoLocation = () => {
+  const [location, setLocation] = useState<LatLong | undefined>(
+    getLocationFromLocalStorage(),
+  )
+  useEffect(() => {
+    const locationPromise = getLocation()
+    locationPromise.then(loc =>
+      localStorage.setItem(locationKey, JSON.stringify(loc)),
+    )
+    locationPromise.then(setLocation)
+  }, [])
+  return location
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -13,6 +13,7 @@ declare const process: {
   env: {
     NODE_ENV?: string
     PEREGRINE_API_URL?: string
+    IPDATA_API_KEY?: string
     BRANCH?: string
     ROLLUP?: 'true' | 'false'
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const postcssConfig = require('./postcss.config')
 const WebpackBar = require('webpackbar')
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin')
+require('dotenv').config()
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
 //   .BundleAnalyzerPlugin
 


### PR DESCRIPTION
https://improve-event-sorting--peregrine.netlify.com/

Now it sorts them good:

1. *Current Events* - Sorted by proximity, then by name
2. *Future Events* - Sorted by soonest upcoming first
3. *Past Events* - Sorted by most recent first

It also now works correctly for the last day of the event, it still shows them as active until the end of the endDate (even though the endDate timestamp is the very beginning of the day)

It also works correctly with event timezones, it preserves the date into the current timezone, which fixes problems with the event day being off by one