### PR TITLE
Fix matches link

### DIFF
--- a/src/routes/event-team.tsx
+++ b/src/routes/event-team.tsx
@@ -109,7 +109,7 @@ const EventTeam = ({ eventKey, teamNum }: Props) => {
               )
               .map(c => (
                 <li key={c.id}>
-                  <a href={`/events/${eventKey}/match/${c.matchKey}`}>
+                  <a href={`/events/${eventKey}/matches/${c.matchKey}`}>
                     {formatMatchKey(c.matchKey).group}
                   </a>
                   : {c.comment}


### PR DESCRIPTION
Now when you click on the link from a comment on a team that goes to the match, the link works, instead of not

Closes #540 