### PR TITLE
Use gmapsUrl from TBA rather than lat/lon directly

### DIFF
--- a/src/api/event-info/index.ts
+++ b/src/api/event-info/index.ts
@@ -7,6 +7,8 @@ export interface EventInfo {
   // district "display_name" from TBA
   fullDistrict?: string
   locationName: string
+  lat?: number
+  lon?: number
   gmapsUrl?: string
   key: string
   // the ID of the realm the event belongs to

--- a/src/api/event-info/index.ts
+++ b/src/api/event-info/index.ts
@@ -7,8 +7,7 @@ export interface EventInfo {
   // district "display_name" from TBA
   fullDistrict?: string
   locationName: string
-  lat?: number
-  lon?: number
+  gmapsUrl?: string
   key: string
   // the ID of the realm the event belongs to
   realmId?: string

--- a/src/components/event-info-card.tsx
+++ b/src/components/event-info-card.tsx
@@ -15,9 +15,6 @@ import { ProcessedEventInfo } from '@/api/event-info'
 import { youtube } from '@/icons/youtube'
 import { twitch } from '@/icons/twitch'
 
-const gmapsUrl = (lat: number, lon: number) =>
-  `https://www.google.com/maps/?q=${lat},${lon}`
-
 const gcalDate = (date: Date, dateOffset = 0) => {
   return (
     String(date.getFullYear()) +
@@ -55,11 +52,10 @@ export const EventInfoCard = ({ event }: Props) =>
     <InfoGroupCard
       info={[
         event.locationName &&
-          event.lat &&
-          event.lon && {
+          event.gmapsUrl && {
             icon: mapMarker,
             title: event.locationName,
-            href: gmapsUrl(event.lat, event.lon),
+            href: event.gmapsUrl,
             target: '_blank',
             rel: 'noopener',
             action: <Icon icon={googleMaps} />,


### PR DESCRIPTION
We are currently plugging event lat/lon directly into Google Maps, this doesn't show the name or details of the event space. TBA provides full Google Maps URLs for events, using this instead is a bit nicer.