### PR TITLE
Fix bug

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -29,13 +29,17 @@ export const Router = ({
   onChange: () => void
 }) => {
   const [url, setUrl] = useState(window.location.pathname)
+  const updateUrl = (url: string) => {
+    setUrl(url)
+    setResolvedComponent(null)
+  }
 
   const parsedRoutes = useMemo(() => routes.map(route => parse(route.path)), [
     routes,
   ])
 
   useEffect(() => {
-    routers.push(setUrl)
+    routers.push(updateUrl)
   }, [])
 
   useEffect(() => {
@@ -45,8 +49,7 @@ export const Router = ({
       e.preventDefault()
       e.stopPropagation()
       e.stopImmediatePropagation()
-      setUrl(location.pathname)
-      setResolvedComponent(null)
+      updateUrl(location.pathname)
     }
     window.addEventListener('popstate', historyListener)
     return () => window.removeEventListener('popstate', historyListener)

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,9 +17,7 @@ interface Route {
 const routers: ((url: string) => void)[] = []
 
 export const route = (url: string) => {
-  routers.forEach(router => {
-    router(url)
-  })
+  routers.forEach(router => router(url))
   history.pushState(null, '', url)
 }
 
@@ -48,6 +46,7 @@ export const Router = ({
       e.stopPropagation()
       e.stopImmediatePropagation()
       setUrl(location.pathname)
+      setResolvedComponent(null)
     }
     window.addEventListener('popstate', historyListener)
     return () => window.removeEventListener('popstate', historyListener)


### PR DESCRIPTION
Before when you went to the event analysis page, and then clicked on a team on the table to go to the event team page, then you could do two things that made it break:

- You could use the browser navigation to go quickly forwards/backwards which would break everything
- You could press the back button in the UI which would cause a thing to break in a way that the user couldn't see, but you could see in the console