### PR TITLE
Revert "Get events from all years from the BE (#732)"

### DIFF
--- a/src/api/event-info/get-events.ts
+++ b/src/api/event-info/get-events.ts
@@ -19,7 +19,7 @@ const updateCachedEvents = (events: ProcessedEventInfo[]) =>
 // user is a super-admin, they will see all events, otherwise they will see all
 // TBA events and additionally all the custom events on their realm.
 export const getEvents = () =>
-  request<EventInfo[]>('GET', 'events', { tbaDeleted: 'true' })
+  request<EventInfo[]>('GET', 'events')
     .then(events => events.map(processEvent))
     .then(events => {
       requestIdleCallback(() => updateCachedEvents(events))


### PR DESCRIPTION
Reverts Pigmice2733/peregrine-frontend#732

Because currently `dev` is showing events from all years (so if you search for wilsonville, it shows 2 wilsonvilles, without telling you which is which).

We will be implementing the ability to filter by year in the BE, and then a follow up PR will be implemented here to add a `year` dropdown