### PR TITLE
Add event year filtering

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -7,6 +7,8 @@ module.exports = {
   plugins: [
     process.env.NODE_ENV === 'production' &&
       './babel-plugin-remove-preact-debug',
+    process.env.NODE_ENV !== 'production' &&
+      '@babel/plugin-transform-react-jsx-source',
     ['const-enum', { transform: 'constObject' }], // for TS const enum which babel ts doesn't support natively. See https://github.com/babel/babel/issues/8741
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-nullish-coalescing-operator', { loose: true }],

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -8,6 +8,7 @@ module.exports = {
     process.env.NODE_ENV === 'production' &&
       './babel-plugin-remove-preact-debug',
     process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
       '@babel/plugin-transform-react-jsx-source',
     ['const-enum', { transform: 'constObject' }], // for TS const enum which babel ts doesn't support natively. See https://github.com/babel/babel/issues/8741
     ['@babel/plugin-proposal-class-properties', { loose: true }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -414,6 +414,16 @@
         "@babel/plugin-syntax-jsx": "^7.8.3"
       }
     },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.8.3.tgz",
+      "integrity": "sha512-PLMgdMGuVDtRS/SzjNEQYUT8f4z1xb2BAT54vM1X5efkVuYBf5WyGUMbpmARcfq3NaglIwz08UVQK4HHHbC6ag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-jsx": "^7.8.3"
+      }
+    },
     "@babel/plugin-transform-template-literals": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/plugin-transform-modules-commonjs": "7.8.3",
     "@babel/plugin-transform-react-jsx": "7.8.3",
+    "@babel/plugin-transform-react-jsx-source": "^7.8.3",
     "@babel/plugin-transform-template-literals": "7.8.3",
     "@babel/preset-modules": "0.1.2",
     "@babel/preset-typescript": "7.8.3",

--- a/src/api/event-info/get-events.ts
+++ b/src/api/event-info/get-events.ts
@@ -4,12 +4,25 @@ import { transaction } from '@/cache'
 import { requestIdleCallback } from '@/utils/request-idle-callback'
 import { idbPromise } from '@/utils/idb-promise'
 
-const updateCachedEvents = (events: ProcessedEventInfo[]) =>
+const updateCachedEvents = (events: ProcessedEventInfo[], year?: number) =>
   transaction(
     'events',
-    async eventStore => {
-      // remove all existing events, in case any have been deleted
-      await idbPromise(eventStore.clear())
+    eventStore => {
+      // Remove events that are in cache but no longer exist on the server
+      idbPromise(eventStore.getAll()).then(
+        (allEvents: ProcessedEventInfo[]) => {
+          allEvents.forEach(event => {
+            // If the event is from the year that we requested, but did not come back in the response
+            if (
+              event.endDate.getFullYear() === year &&
+              !events.some(e => e.key === event.key)
+            ) {
+              // Remove it
+              eventStore.delete(event.key)
+            }
+          })
+        },
+      )
       events.forEach(event => eventStore.put(event, event.key))
     },
     'readwrite',
@@ -18,10 +31,10 @@ const updateCachedEvents = (events: ProcessedEventInfo[]) =>
 // Getting events will only list TBA events, unless a user is signed in. If the
 // user is a super-admin, they will see all events, otherwise they will see all
 // TBA events and additionally all the custom events on their realm.
-export const getEvents = () =>
-  request<EventInfo[]>('GET', 'events')
+export const getEvents = (year?: number) =>
+  request<EventInfo[]>('GET', 'events', { year })
     .then(events => events.map(processEvent))
     .then(events => {
-      requestIdleCallback(() => updateCachedEvents(events))
+      requestIdleCallback(() => updateCachedEvents(events, year))
       return events
     })

--- a/src/api/get-years.ts
+++ b/src/api/get-years.ts
@@ -1,0 +1,4 @@
+import { request } from './base'
+
+/** Returns all the years for which we have events */
+export const getYears = () => request<number[]>('GET', 'years')

--- a/src/api/match-info/get-event-matches.ts
+++ b/src/api/match-info/get-event-matches.ts
@@ -19,9 +19,10 @@ const updateCachedEventMatches = (
   )
 
 export const getEventMatches = (eventKey: string, team?: string) =>
-  request<MatchInfo[]>('GET', `events/${eventKey}/matches`, { team })
-    .then(matches => matches.map(processMatch))
-    .then(matches => {
-      requestIdleCallback(() => updateCachedEventMatches(eventKey, matches))
-      return matches
-    })
+  request<MatchInfo[]>('GET', `events/${eventKey}/matches`, { team }).then(
+    matches => {
+      const processed = matches.map(processMatch)
+      requestIdleCallback(() => updateCachedEventMatches(eventKey, processed))
+      return processed
+    },
+  )

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,20 +7,20 @@ import routes from './routes'
 import GAnalytics from 'ganalytics'
 import { requestIdleCallback } from '@/utils/request-idle-callback'
 import { uploadSavedReports } from './api/report/submit-report'
+import { addUrlListener } from './url-manager'
 
-const ga = GAnalytics('UA-144107080-1', {}, true)
-
-const sendGa =
-  process.env.NODE_ENV === 'production'
-    ? () =>
-        requestIdleCallback(() => {
-          ga.send('pageview', {
-            dl: location.href,
-            dt: document.title,
-            dh: location.hostname,
-          })
-        })
-    : () => {}
+if (process.env.NODE_ENV === 'production') {
+  const ga = GAnalytics('UA-144107080-1', {}, true)
+  addUrlListener(() =>
+    requestIdleCallback(() => {
+      ga.send('pageview', {
+        dl: location.href,
+        dt: document.title,
+        dh: location.hostname,
+      })
+    }),
+  )
+}
 
 setTimeout(uploadSavedReports, 2_000)
 setInterval(uploadSavedReports, 30_000)
@@ -28,7 +28,7 @@ setInterval(uploadSavedReports, 30_000)
 const App = () => (
   <Fragment>
     <div>
-      <Router routes={routes} onChange={sendGa} />
+      <Router routes={routes} />
     </div>
     <DialogDisplayer />
   </Fragment>

--- a/src/cache/events/get-cached.ts
+++ b/src/cache/events/get-cached.ts
@@ -2,7 +2,9 @@ import { transaction } from '..'
 import { ProcessedEventInfo } from '@/api/event-info'
 import { preventEmptyArrResolve } from '@/utils/prevent-empty-arr-resolve'
 
-export const getCachedEvents = () =>
-  transaction<ProcessedEventInfo[]>('events', eventStore =>
-    eventStore.getAll(),
-  ).then(preventEmptyArrResolve)
+export const getCachedEvents = (year?: number) =>
+  transaction<ProcessedEventInfo[]>('events', eventStore => eventStore.getAll())
+    .then(preventEmptyArrResolve)
+    .then(events =>
+      year ? events.filter(e => e.endDate.getFullYear() === year) : events,
+    )

--- a/src/components/authenticated/index.test.tsx
+++ b/src/components/authenticated/index.test.tsx
@@ -40,6 +40,7 @@ test('renders login form', async () => {
         body: '{"username":"user name","password":"pass word"}',
         headers: {},
         method: 'POST',
+        signal: expect.any(AbortSignal),
       },
     ),
   )

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -27,6 +27,7 @@ import Icon from './icon'
 import { checkBold } from '@/icons/check-bold'
 import { xBold } from '@/icons/x-bold'
 import { formatMatchKeyShort } from '@/utils/format-match-key-short'
+import { CancellablePromise } from '@/utils/cancellable-promise'
 
 interface ChartCardProps {
   team: string
@@ -65,7 +66,7 @@ export const ChartCard: FunctionComponent<ChartCardProps> = ({
   const matchesStats =
     usePromise(
       () =>
-        Promise.all(
+        CancellablePromise.all(
           teamMatches.sort(compareMatches).map(async match => ({
             matchKey: match.key,
             stats: await getMatchTeamStats(eventKey, match.key, team)

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -30,9 +30,9 @@ type Props<T> = {
   onChange: (v: T) => void
   getKey?: (v: T) => string | number
   getText?: (v: T) => string
-} & (T extends string
-  ? {}
-  : { getKey: (v: T) => string | number; getText: (v: T) => string })
+} & (T extends object
+  ? { getKey: (v: T) => string | number; getText: (v: T) => string }
+  : {})
 
 export const Dropdown = <T extends any>({
   options,

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -48,10 +48,10 @@ const Home = () => {
     usePromise(getYears) ||
     (cachedEventsFromAllYears
       ? [
-          ...cachedEventsFromAllYears.reduce(
-            (years, e) => (years.add(e.endDate.getFullYear()), years),
-            new Set<number>(),
-          ),
+          ...cachedEventsFromAllYears.reduce((years, e) => {
+            years.add(e.endDate.getFullYear())
+            return years
+          }, new Set<number>()),
         ].sort()
       : [currentYear])
 

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -8,44 +8,82 @@ import { useEvents } from '@/cache/events/use'
 import { useState } from 'preact/hooks'
 import TextInput from '@/components/text-input'
 import { css } from 'linaria'
+import { Dropdown } from '@/components/dropdown'
+import { useQueryState } from '@/utils/use-query-state'
+import { getYears } from '@/api/get-years'
+import { usePromise } from '@/utils/use-promise'
+import { getCachedEvents } from '@/cache/events/get-cached'
+import { UnstyledList } from '@/components/unstyled-list'
 
 const homeStyle = css`
   display: grid;
-  grid-gap: 0.7rem;
   justify-content: center;
   margin: 1rem;
+  grid-gap: 1rem;
   grid-template-columns: minmax(auto, 23rem);
 `
 
+const matchListStyle = css`
+  display: grid;
+  grid-gap: 1rem;
+`
+
+const filterStyle = css`
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  grid-gap: 1rem;
+`
+
 const now = new Date()
+const currentYear = now.getFullYear()
 const Home = () => {
-  const events = useEvents()
   const location = useGeoLocation()
-  const [term, setTerm] = useState('')
-  const lowerCaseQuery = term.toString().toLowerCase()
+  const [query, setQuery] = useState('')
+  const lowerCaseQuery = query.toLowerCase()
+  const [yearVal, setYear] = useQueryState('year', currentYear)
+  const year = Number(yearVal)
+  const events = useEvents(year)
+  const cachedEventsFromAllYears = usePromise(getCachedEvents)
+  const years =
+    usePromise(getYears) ||
+    (cachedEventsFromAllYears
+      ? [
+          ...cachedEventsFromAllYears.reduce(
+            (years, e) => (years.add(e.endDate.getFullYear()), years),
+            new Set<number>(),
+          ),
+        ].sort()
+      : [currentYear])
 
   return (
     <Page name="Home" back={false} class={homeStyle}>
-      <TextInput onInput={setTerm} label="Search for Events" />
+      <div class={filterStyle}>
+        <Dropdown options={years} onChange={setYear} value={year} />
+        <TextInput onInput={setQuery} label="Search for Events" />
+      </div>
 
       {events ? (
         <Fragment>
-          {events
-            .filter(event => {
-              if (!term) return true
-              return (
-                event.name.toLowerCase().includes(lowerCaseQuery) ||
-                event.key.toLowerCase().includes(lowerCaseQuery) ||
-                event.locationName.toLowerCase().includes(lowerCaseQuery) ||
-                event.district?.toLowerCase().includes(lowerCaseQuery) ||
-                event.fullDistrict?.toLowerCase().includes(lowerCaseQuery)
-              )
-            })
-            .sort(compareEvents(now, location))
-            .slice(0, 20) // Displaying just the first 20 to improve rendering/re-rendering performance (esp. while searching)
-            .map(e => (
-              <EventCard key={e.key} event={e} />
-            ))}
+          <UnstyledList class={matchListStyle}>
+            {events
+              .filter(event => {
+                if (!query) return true
+                return (
+                  event.name.toLowerCase().includes(lowerCaseQuery) ||
+                  event.key.toLowerCase().includes(lowerCaseQuery) ||
+                  event.locationName.toLowerCase().includes(lowerCaseQuery) ||
+                  event.district?.toLowerCase().includes(lowerCaseQuery) ||
+                  event.fullDistrict?.toLowerCase().includes(lowerCaseQuery)
+                )
+              })
+              .sort(compareEvents(now, location))
+              .slice(0, 20) // Displaying just the first 20 to improve rendering/re-rendering performance (esp. while searching)
+              .map(e => (
+                <li key={e.key}>
+                  <EventCard event={e} />
+                </li>
+              ))}
+          </UnstyledList>
           <a
             href="https://www.netlify.com"
             class={css`

--- a/src/url-manager.ts
+++ b/src/url-manager.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'preact/hooks'
+import { decode, encode, Val as URLVal, QueryObj } from 'qss'
+
+const urlListeners = new Set<() => void>()
+
+export const addUrlListener = (cb: () => void) => urlListeners.add(cb)
+
+const handleUrlChange = () => urlListeners.forEach(l => l())
+
+window.addEventListener('popstate', handleUrlChange)
+
+/**
+ * @param newPartialUrl The new URL for the page to have (could be a partial url such as a hash, path, or query string)
+ * @param replace Whether the previous url should be replaced rather than creating a new history entry
+ */
+export const updateUrl = (newPartialUrl: string, replace = false) => {
+  history[replace ? 'replaceState' : 'pushState'](null, '', newPartialUrl)
+  handleUrlChange()
+}
+
+/** Returns a URL object when the URL changes */
+export const useUrl = <T>(urlPartGetter: (location: Location) => T): T => {
+  const [value, setValue] = useState<T>(urlPartGetter(location))
+  useEffect(() => {
+    const listener = () => setValue(urlPartGetter(location))
+    urlListeners.add(listener)
+    return () => urlListeners.delete(listener)
+  }, [urlPartGetter])
+  return value
+}
+
+const getQueryParams = (): QueryObj =>
+  decode(
+    // removes the ?
+    location.search.slice(1),
+  )
+
+export const useQueryParam = (name: string) =>
+  useUrl(() => getQueryParams()[name])
+
+export const updateQueryParam = (name: string, value: URLVal) => {
+  updateUrl(encode({ ...getQueryParams(), [name]: value }, '?'))
+}

--- a/src/utils/cancellable-promise/index.test.ts
+++ b/src/utils/cancellable-promise/index.test.ts
@@ -1,0 +1,145 @@
+import { CancellablePromise } from '.'
+
+const nextTick = () => new Promise(r => setTimeout(r, 0))
+// const nextTick = () => Promise.resolve()
+
+describe('behaves like a normal promise', () => {
+  it('only resolves once', async () => {
+    let resolve: (value?: string | PromiseLike<string>) => void = () => {}
+    let reject: (reason?: any) => void = () => {}
+    const promise: Promise<string> = new CancellablePromise<string>(
+      (res, rej) => {
+        resolve = res
+        reject = rej
+      },
+    )
+
+    const beforeCallback = jest.fn()
+    promise.then(beforeCallback)
+    expect(beforeCallback).not.toHaveBeenCalled()
+
+    resolve('hi')
+
+    await nextTick()
+
+    expect(beforeCallback).toHaveBeenCalledTimes(1)
+    expect(beforeCallback).toHaveBeenLastCalledWith('hi')
+
+    const afterCallback = jest.fn()
+
+    promise.then(afterCallback)
+
+    await nextTick()
+
+    expect(afterCallback).toHaveBeenCalledTimes(1)
+    expect(afterCallback).toHaveBeenCalledWith('hi')
+
+    reject()
+
+    // Catch should not have called, since it already resolved
+    const catchCallback = jest.fn()
+    promise.catch(catchCallback)
+    await nextTick()
+    expect(catchCallback).not.toHaveBeenCalled()
+
+    resolve('hi again')
+    // Should not call then again, since it already resolved
+    expect(afterCallback).toHaveBeenCalledTimes(1)
+    expect(afterCallback).toHaveBeenCalledWith('hi')
+  })
+
+  it('resolves correct value from catch', async () => {
+    let reject: (reason?: any) => void = () => {}
+    const promise: Promise<string> = new CancellablePromise<string>(
+      (_res, rej) => {
+        reject = rej
+      },
+    )
+
+    const onResolve = jest.fn()
+    const onReject = jest.fn(
+      () => new Promise<number>(resolve => resolve(30)),
+    )
+    const onResolve2 = jest.fn()
+
+    const p1 = promise
+    const p2 = p1.then(onResolve)
+    const p3 = p2.catch(onReject)
+    const p4 = p3.then(onResolve2)
+    await nextTick()
+    expect(onResolve).not.toHaveBeenCalled()
+    expect(onReject).not.toHaveBeenCalled()
+    expect(onResolve2).not.toHaveBeenCalled()
+
+    reject('bad')
+
+    expect(p4).toBeInstanceOf(CancellablePromise)
+
+    await nextTick()
+    await nextTick()
+    expect(onResolve).not.toHaveBeenCalled()
+    expect(onReject).toHaveBeenCalledTimes(1)
+    expect(onReject).toHaveBeenCalledWith('bad')
+    await nextTick()
+    await nextTick()
+    await nextTick()
+    expect(onResolve2).toHaveBeenCalledTimes(1)
+    expect(onResolve2).toHaveBeenCalledWith(30)
+  })
+})
+
+describe('cancellable functionality', () => {
+  it('cancelling prevents .then and .catch callbacks from being called', async () => {
+    let resolve: (value?: string | PromiseLike<string>) => void = () => {}
+    let reject: (reason?: any) => void = () => {}
+    const cancelCallback = jest.fn()
+    const promise = new CancellablePromise<string>((res, rej, onCanceled) => {
+      resolve = res
+      reject = rej
+      onCanceled(cancelCallback)
+    })
+
+    const thenCallback = jest.fn()
+    promise.then(thenCallback)
+
+    expect(cancelCallback).not.toHaveBeenCalled()
+
+    promise
+      .then(() => {})
+      .catch(() => {})
+      .cancel()
+
+    expect(cancelCallback).toHaveBeenCalledTimes(1)
+    expect(cancelCallback).toHaveBeenCalledWith()
+
+    resolve('hi')
+    reject()
+
+    await nextTick()
+
+    expect(thenCallback).not.toHaveBeenCalled()
+  })
+
+  it('cancels subpromises with Promise.all', async () => {
+    const onP1Cancel = jest.fn()
+    const onP2Cancel = jest.fn()
+    const p1 = new CancellablePromise<string>((_res, _rej, onCanceled) => {
+      onCanceled(onP1Cancel)
+    })
+    const p2 = new CancellablePromise<string>((_res, _rej, onCanceled) => {
+      onCanceled(onP2Cancel)
+    })
+    const p3 = new Promise<never>(() => {})
+    const all = CancellablePromise.all([p1, p2, p3])
+    expect(all).toBeInstanceOf(CancellablePromise)
+    await nextTick()
+    expect(onP1Cancel).not.toHaveBeenCalled()
+    expect(onP2Cancel).not.toHaveBeenCalled()
+    all.cancel()
+    await nextTick()
+    await nextTick()
+    await nextTick()
+    expect(onP1Cancel).toHaveBeenCalledTimes(1)
+    expect(onP2Cancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/utils/cancellable-promise/index.test.ts
+++ b/src/utils/cancellable-promise/index.test.ts
@@ -1,7 +1,6 @@
 import { CancellablePromise } from '.'
 
-const nextTick = () => new Promise(r => setTimeout(r, 0))
-// const nextTick = () => Promise.resolve()
+const nextTick = () => Promise.resolve()
 
 describe('behaves like a normal promise', () => {
   it('only resolves once', async () => {

--- a/src/utils/cancellable-promise/index.ts
+++ b/src/utils/cancellable-promise/index.ts
@@ -1,0 +1,198 @@
+/* eslint-disable caleb/shopify/prefer-class-properties */
+
+type OnCanceled = (cb: () => void) => void
+type Executor<T> = (
+  resolve: (value?: T | PromiseLike<T>) => void,
+  reject: (reason?: any) => void,
+  onCanceled: OnCanceled,
+) => void
+
+class CancellablePromise<T> extends Promise<T> {
+  private isCanceled: boolean
+  private cancelListeners: Set<() => void>
+
+  static wrapAsync<T>(
+    asyncFunc: (onCanceled: OnCanceled) => Promise<T>,
+  ): CancellablePromise<T> {
+    return new CancellablePromise((resolve, reject, onCancel) =>
+      asyncFunc(onCancel).then(resolve, reject),
+    )
+  }
+
+  static all(promises: Iterable<any>): CancellablePromise<any> {
+    return new CancellablePromise((resolve, reject, onCancel) => {
+      Promise.all(promises).then(resolve, reject)
+      onCancel(() => {
+        for (const p of promises) {
+          if (p instanceof CancellablePromise) p.cancel()
+        }
+      })
+    })
+  }
+
+  constructor(executor: Executor<T>) {
+    const cancelListeners = new Set<() => void>()
+    super((resolve, reject) => {
+      const onCanceled = (cb: () => void) => cancelListeners.add(cb)
+      executor(resolve, reject, onCanceled)
+    })
+    this.isCanceled = false
+    this.cancelListeners = cancelListeners
+  }
+
+  cancel() {
+    if (this.isCanceled) return
+    this.isCanceled = true
+    this.cancelListeners.forEach(cb => cb())
+  }
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): CancellablePromise<TResult1 | TResult2> {
+    const p = new CancellablePromise<TResult1 | TResult2>(
+      (resolve, reject, onCancel) => {
+        super.then(
+          val => {
+            if (!this.isCanceled)
+              resolve(
+                onfulfilled ? onfulfilled(val) : ((val as any) as TResult1),
+              )
+          },
+          val => {
+            if (this.isCanceled) return
+            if (onrejected) resolve(onrejected(val))
+            // If there is no catcher, the sub-promise should reject
+            else reject(val)
+          },
+        )
+        // When the chained promise cancels, this one should too
+        // fetch().then(...).then(...).cancel() should cancel the first promise
+        onCancel(() => this.cancel())
+      },
+    )
+    return p
+  }
+  catch<TResult = never>(
+    onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
+  ): CancellablePromise<T | TResult> {
+    return this.then(null, onrejected)
+  }
+}
+
+CancellablePromise.resolve()
+
+type CPromise<T> = CancellablePromise<T>
+const CPromise = CancellablePromise as CancellablePromiseConstructor
+
+export { CPromise as CancellablePromise }
+
+interface CancellablePromise<T> {
+  catch<TResult = never>(
+    onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
+  ): CancellablePromise<T | TResult>
+}
+
+interface CancellablePromiseConstructor extends PromiseConstructor {
+  readonly prototype: CancellablePromise<any>
+  new <T>(executor: Executor<T>): CancellablePromise<T>
+
+  wrapAsync<T>(
+    asyncFunc: (onCanceled: OnCanceled) => Promise<T>,
+  ): CancellablePromise<T>
+
+  resolve: {
+    <T>(value: T | PromiseLike<T>): CancellablePromise<T>
+    (): CancellablePromise<void>
+  }
+
+  all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+      T4 | PromiseLike<T4>,
+      T5 | PromiseLike<T5>,
+      T6 | PromiseLike<T6>,
+      T7 | PromiseLike<T7>,
+      T8 | PromiseLike<T8>,
+      T9 | PromiseLike<T9>,
+      T10 | PromiseLike<T10>,
+    ],
+  ): CancellablePromise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>
+  all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+      T4 | PromiseLike<T4>,
+      T5 | PromiseLike<T5>,
+      T6 | PromiseLike<T6>,
+      T7 | PromiseLike<T7>,
+      T8 | PromiseLike<T8>,
+      T9 | PromiseLike<T9>,
+    ],
+  ): CancellablePromise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>
+  all<T1, T2, T3, T4, T5, T6, T7, T8>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+      T4 | PromiseLike<T4>,
+      T5 | PromiseLike<T5>,
+      T6 | PromiseLike<T6>,
+      T7 | PromiseLike<T7>,
+      T8 | PromiseLike<T8>,
+    ],
+  ): CancellablePromise<[T1, T2, T3, T4, T5, T6, T7, T8]>
+  all<T1, T2, T3, T4, T5, T6, T7>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+      T4 | PromiseLike<T4>,
+      T5 | PromiseLike<T5>,
+      T6 | PromiseLike<T6>,
+      T7 | PromiseLike<T7>,
+    ],
+  ): CancellablePromise<[T1, T2, T3, T4, T5, T6, T7]>
+  all<T1, T2, T3, T4, T5, T6>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+      T4 | PromiseLike<T4>,
+      T5 | PromiseLike<T5>,
+      T6 | PromiseLike<T6>,
+    ],
+  ): CancellablePromise<[T1, T2, T3, T4, T5, T6]>
+  all<T1, T2, T3, T4, T5>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+      T4 | PromiseLike<T4>,
+      T5 | PromiseLike<T5>,
+    ],
+  ): CancellablePromise<[T1, T2, T3, T4, T5]>
+  all<T1, T2, T3, T4>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+      T4 | PromiseLike<T4>,
+    ],
+  ): CancellablePromise<[T1, T2, T3, T4]>
+  all<T1, T2, T3>(
+    values: readonly [
+      T1 | PromiseLike<T1>,
+      T2 | PromiseLike<T2>,
+      T3 | PromiseLike<T3>,
+    ],
+  ): CancellablePromise<[T1, T2, T3]>
+  all<T1, T2>(
+    values: readonly [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>],
+  ): CancellablePromise<[T1, T2]>
+  all<T>(values: readonly (T | PromiseLike<T>)[]): CancellablePromise<T[]>
+  all<TAll>(values: Iterable<TAll | PromiseLike<TAll>>): Promise<TAll[]>
+}

--- a/src/utils/fastest-promise/index.ts
+++ b/src/utils/fastest-promise/index.ts
@@ -1,8 +1,13 @@
+import { CancellablePromise } from '@/utils/cancellable-promise'
+
 /**
  * Like Promise.race, but it only rejects if both promises reject
  */
-export const fastestPromise = <T>(a: Promise<T>, b: Promise<T>): Promise<T> =>
-  new Promise((resolve, reject) => {
+export const fastestPromise = <T>(
+  a: Promise<T>,
+  b: Promise<T>,
+): CancellablePromise<T> =>
+  new CancellablePromise((resolve, reject) => {
     let resolved: false | T = false
     let rejected = false
 

--- a/src/utils/use-promise/index.tsx
+++ b/src/utils/use-promise/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'preact/hooks'
 import { useErrorEmitter } from '@/components/error-boundary'
+import { CancellablePromise } from '@/utils/cancellable-promise'
 
 export const usePromise = <T extends any>(
   promiseCreator: () => Promise<T> | undefined,
@@ -11,6 +12,7 @@ export const usePromise = <T extends any>(
     const promise = promiseCreator()
     if (!promise) return
     promise.then(v => setVal(v)).catch(emitError)
+    if (promise instanceof CancellablePromise) return () => promise.cancel()
   }, [emitError, ...dependencies]) // eslint-disable-line caleb/react-hooks/exhaustive-deps
   return val
 }

--- a/src/utils/use-query-state.ts
+++ b/src/utils/use-query-state.ts
@@ -1,34 +1,16 @@
-import { useEffect, useState } from 'preact/hooks'
-import { decode, encode } from 'qss'
+import { Val as URLVal } from 'qss'
+import { useQueryParam, updateQueryParam } from '@/url-manager'
 
-const getParams = () =>
-  decode(
-    location.search.slice(1), // removes the "?"
-  )
-const updateQueryParam = (newValue: any, name: string) => {
-  const params = getParams()
-  params[name] = newValue
-  history.replaceState(null, '', '?' + encode(params))
-}
-export const useQueryState = <T>(name: string, initialState?: T) => {
-  const [value, setStateValue] = useState(initialState)
-  useEffect(() => {
-    if (!(name in getParams()) && initialState !== undefined) {
-      updateQueryParam(initialState, name)
-    }
-    const handleUrlChange = () => {
-      const newValue: T = getParams()[name] || initialState
-      setStateValue(newValue)
-    }
-    handleUrlChange()
-    window.addEventListener('popstate', handleUrlChange)
-    return () => window.removeEventListener('popstate', handleUrlChange)
-  }, [initialState, name])
+export const useQueryState = <DefaultVal extends URLVal = undefined>(
+  name: string,
+  initialState?: DefaultVal,
+) => {
+  const val = useQueryParam(name)
+
   return [
-    value,
-    (newValue: T) => {
-      updateQueryParam(newValue, name)
-      setStateValue(newValue)
+    val ?? initialState,
+    (newValue: URLVal) => {
+      updateQueryParam(name, newValue)
     },
   ] as const
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -59,7 +59,7 @@ declare module 'matchit' {
 }
 
 declare module 'qss' {
-  type RawVal = string | number | boolean
+  type RawVal = string | number | boolean | undefined
   type Val = RawVal | RawVal[]
   interface QueryObj {
     [key: string]: Val


### PR DESCRIPTION
https://event-year-filtering--peregrine.netlify.com/

This is a big change. I fixed/improved some things tangentially related to the dropdown I added

---

I created a `CancellablePromise` which took forever. It allows cancelling from anywhere in the promise chain, and cancellations bubble all the way up to the original promise.

Because of that, now HTTP requests get canceled when the requirements change before the response comes back. For example, using the year dropdown, if you switch back and forth very fast, it will cancel requests that didn't finish before the dropdown was switched. Before this change, this would happen on slow networks:

- Filter = 2019
- Retrieve + display 2019 events from cache
- Start request for 2019 events
- Filter changed to 2020
- Retrieve + display 2020 events from cache
- Start request for 2020 events
- Finished request from 2019 events. Those get displayed (janky and wrong)
- Finished request for 2020 events. Then they get displayed

The request cancellation fixes that. This change is implemented in useNetworkCache which is used across the site, so this should benefit many similar places

This also fixes the bug we were seeing occasionally where it said "this.setState was called on an unmounted component, this indicates a memory leak". One of the ways that this error was triggered was when network requests would come back after a component was unmounted. But now, those requests will get cancelled when the component gets unmounted.

---
I added the year query parameter to the getEvents function and related caching functions. Initially, when filtering by year, cached events from other years would incorrectly get deleted (i.e. if you filtered for 2019 events, the 2020 events would get deleted from cache because they were missing from the response). That was fixed by only deleting cached events if they were of the same year as the response _and_ they were missing from the response.

---

I added much better URL handling. This is shared between routing and query parameters. Now if there are multiple `useQueryState` calls on the page at the same time, and they are using the same query parameter name, their values will be linked. So if you update one on one side of the app, they will get updated everywhere

Also as a part of this I fixed another instance of "this.setState was called on an unmounted component, this indicates a memory leak". This one was triggering because when navigating from `/?year=2019` to `/events/2019orwil`, both the path and the query parameter were changing. The home component would get rerender right after it was unmounted, because the year filtering query parameter changed. I believe this fixes the bug in other places on the site as well (for example when navigating from analysis table to single-team pages).