### PR TITLE
Improvements to chart dropdown

### DIFF
--- a/src/components/analysis-table.tsx
+++ b/src/components/analysis-table.tsx
@@ -20,6 +20,7 @@ import Icon from './icon'
 import { settings as settingsIcon } from '@/icons/settings'
 import { round } from '@/utils/round'
 import Spinner from './spinner'
+import { cleanFieldName } from '@/utils/clean-field-name'
 
 interface Props {
   teams: ProcessedTeamStats[] | undefined
@@ -50,7 +51,7 @@ const createStatCell = (
 ): Column<StatWithType | undefined, RowType> => {
   const avgTypeStr = avgType === 'Avg' ? 'avg' : 'max'
   return {
-    title: statDescription.name,
+    title: cleanFieldName(statDescription.name),
     getCell: row => {
       const matchingCell = row.summary[statDescription.name]
       if (matchingCell)

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -87,7 +87,10 @@ export const ChartCard = ({
   teamMatches,
   schema,
 }: ChartCardProps) => {
-  const [fieldName, setFieldName] = useQueryState('stat', schema.schema[0].name)
+  const [fieldName, setFieldName] = useQueryState(
+    'stat',
+    schema.schema.find(f => !f.hide)?.name,
+  )
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
   const matchesStats =
     usePromise(

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -11,7 +11,7 @@ import { lerp } from '@/utils/lerp'
 import { getMatchTeamStats } from '@/api/stats/get-match-team-stats'
 import { round } from '@/utils/round'
 import { Dropdown } from './dropdown'
-import { Schema } from '@/api/schema'
+import { Schema, StatDescription } from '@/api/schema'
 import { memo } from '@/utils/memo'
 import { useQueryState } from '@/utils/use-query-state'
 import { formatPercent } from '@/utils/format-percent'
@@ -21,6 +21,7 @@ import { BooleanDisplay } from './boolean-display'
 import { CancellablePromise } from '@/utils/cancellable-promise'
 import { getMatchTeamReports } from '@/api/report/get-match-team-reports'
 import { CommentCard } from './comment-card'
+import { cleanFieldName } from '@/utils/clean-field-name'
 
 const commentsDisplayStyle = css`
   grid-column: 1 / -1;
@@ -125,10 +126,6 @@ export const ChartCard = ({
     if (!(event.target as Element).closest(`.${point}`)) setSelectedIndex(null)
   }
 
-  const statOptions = schema.schema
-    .filter(stat => !stat.hide)
-    .map(stat => stat.name)
-
   const matchingSchemaStat = schema.schema.find(s => s.name === fieldName)
   const isBooleanStat =
     matchingSchemaStat && matchingSchemaStat.type === 'boolean'
@@ -143,11 +140,14 @@ export const ChartCard = ({
         <Chart points={dataPoints} onPointClick={setSelectedIndex} />
       )}
       <div class={chartDescriptionStyle}>
-        <Dropdown
+        <Dropdown<StatDescription>
           class={statPickerStyle}
-          options={statOptions}
-          onChange={setFieldName}
-          value={fieldName}
+          options={schema.schema.filter(s => !s.hide)}
+          getKey={s => s.name}
+          getText={s => cleanFieldName(s.name)}
+          getGroup={s => (s.period === 'auto' ? 'Auto' : 'Teleop')}
+          onChange={s => setFieldName(s.name)}
+          value={matchingSchemaStat}
         />
         <div class={detailsStyle}>
           {noData ? (

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -56,9 +56,6 @@ export const Dropdown = <T extends any>({
     )
     return acc
   }, {} as { [key: string]: JSX.Element[] })
-  console.log(optionsByGroup)
-  const groups = new Set(options.map(o => getGroup(o)).filter(g => g !== null))
-  console.log(groups)
   return (
     // eslint-disable-next-line caleb/jsx-a11y/no-onchange
     <select

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -1,5 +1,5 @@
 import { css } from 'linaria'
-import { h, JSX, Fragment } from 'preact'
+import { h, JSX } from 'preact'
 import clsx from 'clsx'
 import { createShadow } from '@/utils/create-shadow'
 import { SetRequired } from 'type-fest'

--- a/src/components/field-card.tsx
+++ b/src/components/field-card.tsx
@@ -4,6 +4,7 @@ import NumberInput from './number-input'
 import { css } from 'linaria'
 import Toggle from './toggle'
 import { ReportStatDescription, NumberStatDescription } from '@/api/schema'
+import { cleanFieldName } from '@/utils/clean-field-name'
 
 const fieldCardStyle = css`
   display: grid;
@@ -34,7 +35,7 @@ const FieldCard = <FieldType extends ReportStatDescription>({
   value,
 }: RenderableProps<Props<FieldType>>) => (
   <Card as="label" class={fieldCardStyle}>
-    <div class={nameStyle}>{statDescription.name}</div>
+    <div class={nameStyle}>{cleanFieldName(statDescription.name)}</div>
     {isNumberField(statDescription) ? (
       <NumberInput value={value} min={0} onChange={onChange} />
     ) : (

--- a/src/utils/clean-field-name.ts
+++ b/src/utils/clean-field-name.ts
@@ -1,0 +1,3 @@
+// TODO: Remove once we can handle multiple fields of the same name
+export const cleanFieldName = (fieldName: string) =>
+  fieldName.replace(/\((?:auto|teleop)\)/, '').trim()


### PR DESCRIPTION
Now the chart dropdown has the fields grouped into auto and teleop

Also, across the whole app, ` (auto)` and ` (teleop)` is removed from the end of the field names. This is temporary because those were only there for a workaround. When we support auto + teleop fields having the same name, this can be removed

Also, this fixes a bug where the chart dropdown was not auto-selecting the first field correctly. It was trying to select a hidden field, because the first field in this year's schema is hidden

https://default-chart-dropdown--peregrine.netlify.com/events/2020week0/teams/4041

Compare to this which is bad (what is the chart even showing?????)
https://peregrine.ga/events/2020week0/teams/4041

Before:
![image](https://user-images.githubusercontent.com/13206945/74601425-2f0b5180-5053-11ea-9f72-f06f2e4572f9.png)

After:

![image](https://user-images.githubusercontent.com/13206945/74601428-36caf600-5053-11ea-9a05-148c2e36a682.png)
