### PR TITLE
Fix alignment for multiple comments + add link

### DIFF
--- a/src/routes/event-team-comments.tsx
+++ b/src/routes/event-team-comments.tsx
@@ -72,6 +72,7 @@ const EventTeamComments = ({ eventKey, teamNum }: Props) => {
                 key={matchKey}
                 match={matchKey}
                 reports={reports}
+                eventKey={eventKey}
               />
             ))
           )
@@ -88,21 +89,29 @@ const matchCommentsStyle = css`
   grid-template-columns: 4rem 1fr;
   grid-gap: 1.2rem;
 
-  & > span {
+  & > :first-child {
     font-weight: bold;
+  }
+
+  & > :not(:first-child) {
+    grid-column: 2;
   }
 `
 
 const MatchComments = ({
   match,
   reports,
+  eventKey,
 }: {
   match: string
   reports: GetReport[]
+  eventKey: string
 }) => {
   return (
     <div class={matchCommentsStyle}>
-      <span>{formatMatchKeyShort(match)}</span>
+      <a href={`/events/${eventKey}/matches/${match}`}>
+        {formatMatchKeyShort(match)}
+      </a>
       {reports.map(r => (
         <CommentCard key={JSON.stringify(r)} report={r} />
       ))}


### PR DESCRIPTION
Before: 
![screenshot](https://user-images.githubusercontent.com/13206945/75105522-31c4f400-55c9-11ea-8a0a-3902ebfbf44f.png)

After:

![screenshot](https://user-images.githubusercontent.com/13206945/75105526-3b4e5c00-55c9-11ea-9e93-d91bed69e026.png)

- Fixed alignment for multiple comments
- Added link to match

https://improve-team-comments-page--peregrine.netlify.com/events/2020week0/teams/4905/comments
