### PR TITLE
Implement good match sorting+filtering

### DIFF
--- a/src/components/event-matches.tsx
+++ b/src/components/event-matches.tsx
@@ -25,8 +25,8 @@ const matchListStyle = css`
 const enum QueryRank {
   NoMatch,
   TeamLoose,
-  TeamExact,
   MatchLoose,
+  TeamExact,
   MatchExact,
 }
 

--- a/src/components/event-matches.tsx
+++ b/src/components/event-matches.tsx
@@ -59,23 +59,20 @@ export const EventMatches = ({ matches, eventKey }: Props) => {
     return QueryRank.NoMatch
   }
 
-  const sortedMatches = matches
-    .map(match => ({
-      match,
-      queryRank: getQueryRank(match),
-    }))
-    .filter(m => m.queryRank !== QueryRank.NoMatch)
-    .sort((a, b) => {
-      return (
-        b.queryRank - a.queryRank ||
-        compareMatchesChronologically(a.match, b.match)
-      )
-    })
-
-  console.log(sortedMatches)
-
   const filteredMatches = s
-    ? sortedMatches.map(m => m.match)
+    ? matches
+        .map(match => ({
+          match,
+          queryRank: getQueryRank(match),
+        }))
+        .filter(m => m.queryRank !== QueryRank.NoMatch)
+        .sort((a, b) => {
+          return (
+            b.queryRank - a.queryRank ||
+            compareMatchesChronologically(a.match, b.match)
+          )
+        })
+        .map(m => m.match)
     : matches.sort(compareMatchesChronologically)
 
   return (


### PR DESCRIPTION
http://good-match-filtering-sorting--peregrine.netlify.com/events/2019micmp1

This is a good event for a test case, because
- It has a lot of matches
- It has teams 27, 67, and 2767

1. Search for 67
   - Qual 67 should show up first. The match key matches the query exactly. Same if you searched for `qm67` or `qUaL 67`
   - Next is all the matches that include team "67", sorted chronologically
   - Next is all the matches that include teams whose numbers include "67" - so all of 2767's and 5567's and 5676's matches, sorted chronologically
2. Search for 27
3. Search for 67
4. Search for "quarters"
5. Search for "quarters 3"

http://good-match-filtering-sorting--peregrine.netlify.com/events/2019cadm

This is a good event for a test case, because
- It has team 8

1. Search for 8
   - First should be Qual 8, because the match key matches the query exactly
   - Next is all the matches that team 8 played in, sorted chronologically
   - Next is all the matches whose keys/titles loosely match "8" (18, 28, 80), sorted chronologically
   - Next is all the matches which have a team whose number includes "8", sorted chronologically