### PR TITLE
Add teams links to match card

### DIFF
--- a/src/components/event-matches.tsx
+++ b/src/components/event-matches.tsx
@@ -85,11 +85,7 @@ export const EventMatches = ({ matches, eventKey }: Props) => {
       {matches ? (
         <div class={matchListStyle}>
           {filteredMatches.map(m => (
-            <MatchCard
-              href={`/events/${eventKey}/matches/${m.key}`}
-              match={m}
-              key={m.key}
-            />
+            <MatchCard eventKey={eventKey} match={m} key={m.key} link />
           ))}
         </div>
       ) : (

--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -1,4 +1,4 @@
-import { h } from 'preact'
+import { h, Fragment } from 'preact'
 import { formatMatchKey } from '@/utils/format-match-key'
 import { formatTime } from '@/utils/format-time'
 import { formatTeamNumber } from '@/utils/format-team-number'
@@ -14,7 +14,8 @@ interface MatchCardProps {
     time?: Date
   }
   key?: string | number
-  href?: string
+  eventKey: string
+  link?: boolean
 }
 
 const matchCardStyle = css`
@@ -56,13 +57,19 @@ const matchNumStyle = css`
 
 const allianceStyle = css`
   grid-column: 3;
-  color: white;
-  font-weight: bold;
   align-self: stretch;
   margin-left: 0.3rem;
   padding: 0.35rem 0.8rem;
   text-align: center;
   text-align-last: justify;
+  color: white;
+  font-weight: bold;
+
+  & > * {
+    color: white;
+    text-decoration: none;
+    padding: 0.2rem;
+  }
 `
 
 const redStyle = css`
@@ -73,10 +80,25 @@ const blueStyle = css`
   background-color: var(--alliance-blue);
 `
 
-export const MatchCard = memo(({ match, href }: MatchCardProps) => {
+export const MatchCard = memo(({ match, eventKey, link }: MatchCardProps) => {
   const matchName = formatMatchKey(match.key)
+
+  const createTeamLinks = (teams: string[]) =>
+    teams.flatMap((t: string, i) => {
+      const num = formatTeamNumber(t)
+      const El = link ? Fragment : 'a'
+      return [
+        i ? ' ' : null,
+        <El key={num} href={`/events/${eventKey}/teams/${num}`}>
+          {num}
+        </El>,
+      ]
+    })
   return (
-    <Card class={matchCardStyle} href={href}>
+    <Card
+      class={matchCardStyle}
+      href={link ? `/events/${eventKey}/matches/${match.key}` : undefined}
+    >
       <div class={matchTitleStyle}>
         {matchName.num ? <div>{matchName.group}</div> : matchName.group}
         {matchName.num && (
@@ -89,10 +111,10 @@ export const MatchCard = memo(({ match, href }: MatchCardProps) => {
         </time>
       )}
       <div class={`${redStyle} ${allianceStyle}`}>
-        {match.redAlliance.map(t => formatTeamNumber(t)).join(' ')}
+        {createTeamLinks(match.redAlliance)}
       </div>
       <div class={`${blueStyle} ${allianceStyle}`}>
-        {match.blueAlliance.map(t => formatTeamNumber(t)).join(' ')}
+        {createTeamLinks(match.blueAlliance)}
       </div>
     </Card>
   )

--- a/src/routes/event-match.tsx
+++ b/src/routes/event-match.tsx
@@ -104,7 +104,7 @@ const EventMatch = ({ eventKey, matchKey }: Props) => {
       <Button href={`/events/${eventKey}/matches/${matchKey}/scout`}>
         Scout Match
       </Button>
-      {match ? <MatchCard match={match} /> : <Spinner />}
+      {match ? <MatchCard match={match} eventKey={eventKey} /> : <Spinner />}
       {match && matchHasBeenPlayed && (
         <Card class={matchScoreStyle}>
           <div class={redScoreStyle}>{match.redScore}</div>

--- a/src/routes/event-team.tsx
+++ b/src/routes/event-team.tsx
@@ -168,10 +168,7 @@ const EventTeam = ({ eventKey, teamNum }: Props) => {
       {nextMatch && (
         <Fragment>
           <h2 class={sectionStyle}>Next Match</h2>
-          <MatchCard
-            match={nextMatch}
-            href={`/events/${eventKey}/matches/${nextMatch.key}`}
-          />
+          <MatchCard match={nextMatch} eventKey={eventKey} link />
         </Fragment>
       )}
       <InfoGroupCard

--- a/src/routes/event.tsx
+++ b/src/routes/event.tsx
@@ -76,7 +76,8 @@ const Event = ({ eventKey }: Props) => {
           <MatchCard
             key={newestIncompleteMatch.key}
             match={newestIncompleteMatch}
-            href={`/events/${eventKey}/matches/${newestIncompleteMatch.key}`}
+            eventKey={eventKey}
+            link
           />
         )}
         {matches ? (


### PR DESCRIPTION
https://link-from-match-card-to-teams--peregrine.netlify.com/events/2020isde1/matches/qm1

When you are on a match page
The "match card" now links each team to that team's page


This does not apply to match cards that are themselves links (anywhere else on the site)