### PR TITLE
Preserve sort column

### DIFF
--- a/src/components/analysis-table.tsx
+++ b/src/components/analysis-table.tsx
@@ -21,11 +21,12 @@ import { settings as settingsIcon } from '@/icons/settings'
 import { round } from '@/utils/round'
 import Spinner from './spinner'
 import { cleanFieldName } from '@/utils/clean-field-name'
+import { getFieldKey } from '@/utils/get-field-key'
 
 interface Props {
   teams: ProcessedTeamStats[] | undefined
   schema: Schema
-  renderTeam: (team: string) => JSX.Element
+  renderTeam: (team: string, sortColKey: string) => JSX.Element
   renderBoolean?: (cell: StatWithType, avgTypeStr: 'avg' | 'max') => JSX.Element
   enableSettings?: boolean
 }
@@ -60,7 +61,7 @@ const createStatCell = (
           type: statDescription.type,
         }
     },
-    key: statDescription.period + '::' + statDescription.name,
+    key: getFieldKey(statDescription),
     renderCell: cell => {
       const text = cell
         ? cell.type === 'boolean'
@@ -175,10 +176,10 @@ const AnalysisTable = ({
     getCell: row => row.team,
     getCellValue: team => parseInt(team),
     key: 'team',
-    renderCell: (team, _row, rowIndex) => (
+    renderCell: (team, _row, rowIndex, sortColKey) => (
       <th scope="row" class={teamNumCellStyle}>
         <div className={teamRankStyle}>{rowIndex + 1}</div>
-        {renderTeam(team)}
+        {renderTeam(team, sortColKey)}
       </th>
     ),
     sortOrder: SortOrder.ASC,

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -76,6 +76,7 @@ export interface Column<CellType, RowType> {
     cellValue: CellType,
     row: RowType,
     rowIndex: number,
+    sortColKey: string,
   ) => JSX.Element
   /** Function to retrieve the cell value, used for sorting */
   getCellValue: (cellValue: CellType) => number | string | boolean
@@ -210,7 +211,6 @@ export const Table = <RowType extends any>({
     }
     return result
   }
-
   return (
     <table class={tableStyle}>
       <thead>
@@ -238,7 +238,13 @@ export const Table = <RowType extends any>({
       </thead>
       <tbody>
         {rows.sort(compareRows).map((row, index) => (
-          <TableRow key={row.key} row={row} columns={columns} index={index} />
+          <TableRow
+            key={row.key}
+            row={row}
+            columns={columns}
+            index={index}
+            sortColKey={sortColKey}
+          />
         ))}
       </tbody>
     </table>
@@ -276,15 +282,17 @@ const TableRow = <RowType extends any>({
   row,
   columns,
   index,
+  sortColKey,
 }: RenderableProps<{
   row: Row<RowType>
   columns: Column<any, RowType>[]
   index: number
+  sortColKey: string
 }>) => (
   <tr class={tableRowStyle}>
     {columns.map(col => {
       const cell = col.getCell(row.value)
-      return col.renderCell(cell, row.value, index)
+      return col.renderCell(cell, row.value, index, sortColKey)
     })}
   </tr>
 )

--- a/src/routes/event-analysis.tsx
+++ b/src/routes/event-analysis.tsx
@@ -13,6 +13,7 @@ import {
   tablePageTableStyle,
 } from '@/utils/table-page-style'
 import Card from '@/components/card'
+import { eventTeamUrl } from '@/utils/urls/event-team'
 
 interface Props {
   eventKey: string
@@ -43,7 +44,11 @@ const EventAnalysis: FunctionComponent<Props> = ({ eventKey }) => {
             renderTeam={(team, sortColKey) => (
               <a
                 class={teamStyle}
-                href={`/events/${eventKey}/teams/${team}?stat=${sortColKey}`}
+                href={eventTeamUrl(
+                  eventKey,
+                  team,
+                  sortColKey === 'team' ? undefined : sortColKey,
+                )}
               >
                 {team}
               </a>

--- a/src/routes/event-analysis.tsx
+++ b/src/routes/event-analysis.tsx
@@ -40,8 +40,11 @@ const EventAnalysis: FunctionComponent<Props> = ({ eventKey }) => {
           <AnalysisTable
             teams={eventStats}
             schema={schema}
-            renderTeam={team => (
-              <a class={teamStyle} href={`/events/${eventKey}/teams/${team}`}>
+            renderTeam={(team, sortColKey) => (
+              <a
+                class={teamStyle}
+                href={`/events/${eventKey}/teams/${team}?stat=${sortColKey}`}
+              >
                 {team}
               </a>
             )}

--- a/src/routes/event-match.tsx
+++ b/src/routes/event-match.tsx
@@ -21,6 +21,7 @@ import { BooleanDisplay } from '@/components/boolean-display'
 import { matchHasTeam } from '@/utils/match-has-team'
 import { VideoCard } from '@/components/video-card'
 import { cleanYoutubeUrl } from '@/utils/clean-youtube-url'
+import { eventTeamUrl } from '@/utils/urls/event-team'
 
 interface Props {
   eventKey: string
@@ -142,7 +143,7 @@ const EventMatch = ({ eventKey, matchKey }: Props) => {
                 : teamsStats
             }
             schema={schema}
-            renderTeam={(team: string) => (
+            renderTeam={(team, sortColKey) => (
               <a
                 class={clsx(
                   tableTeamStyle,
@@ -150,7 +151,11 @@ const EventMatch = ({ eventKey, matchKey }: Props) => {
                     ? redStyle
                     : blueStyle,
                 )}
-                href={`/events/${eventKey}/teams/${team}`}
+                href={eventTeamUrl(
+                  eventKey,
+                  team,
+                  sortColKey === 'team' ? undefined : sortColKey,
+                )}
               >
                 {team}
               </a>

--- a/src/url-manager.ts
+++ b/src/url-manager.ts
@@ -39,5 +39,7 @@ export const useQueryParam = (name: string) =>
   useUrl(() => getQueryParams()[name])
 
 export const updateQueryParam = (name: string, value: URLVal) => {
-  updateUrl(encode({ ...getQueryParams(), [name]: value }, '?'))
+  updateUrl(
+    encode({ ...getQueryParams(), [name]: value }, '?').replace(/%3A/g, ':'),
+  )
 }

--- a/src/url-manager.ts
+++ b/src/url-manager.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'preact/hooks'
-import { decode, encode, Val as URLVal, QueryObj } from 'qss'
+import { decode, Val as URLVal, QueryObj } from 'qss'
+import { encodeQs } from './utils/encode-qs'
 
 const urlListeners = new Set<() => void>()
 
@@ -39,7 +40,5 @@ export const useQueryParam = (name: string) =>
   useUrl(() => getQueryParams()[name])
 
 export const updateQueryParam = (name: string, value: URLVal) => {
-  updateUrl(
-    encode({ ...getQueryParams(), [name]: value }, '?').replace(/%3A/g, ':'),
-  )
+  updateUrl(encodeQs({ ...getQueryParams(), [name]: value }))
 }

--- a/src/utils/encode-qs.ts
+++ b/src/utils/encode-qs.ts
@@ -1,0 +1,8 @@
+import { encode, QueryObj } from 'qss'
+
+export const encodeQs = (qs: QueryObj) =>
+  encode(qs, '?')
+    // un-encode %3A to : to make URL more readable
+    .replace(/%3A/g, ':')
+    // If it is just a '?' then don't include the ?
+    .replace(/\?$/, '')

--- a/src/utils/get-field-key.ts
+++ b/src/utils/get-field-key.ts
@@ -1,0 +1,6 @@
+import { cleanFieldName } from './clean-field-name'
+import { StatDescription } from '@/api/schema'
+
+export const getFieldKey = (
+  statDescription: Pick<StatDescription, 'name' | 'period'>,
+) => statDescription.period + '::' + cleanFieldName(statDescription.name)

--- a/src/utils/urls/event-team.ts
+++ b/src/utils/urls/event-team.ts
@@ -1,0 +1,7 @@
+import { encodeQs } from '../encode-qs'
+
+export const eventTeamUrl = (
+  eventKey: string,
+  teamNum: string,
+  stat?: string,
+) => `/events/${eventKey}/teams/${teamNum}${encodeQs({ stat })}`


### PR DESCRIPTION
https://preserve-sort-column--peregrine.netlify.com/events/2020week0/analysis

When you are on the analysis table
When you sort by a column other than team
And you tap on the link to that team

The graphs on the team page should default to the stat you were sorting by

Same for when you are on the mini-analysis-table on the event-match page