### PR TITLE
Fix graphs matching field keys

### DIFF
--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -23,7 +23,6 @@ import { getMatchTeamReports } from '@/api/report/get-match-team-reports'
 import { CommentCard } from './comment-card'
 import { cleanFieldName } from '@/utils/clean-field-name'
 import { getFieldKey } from '@/utils/get-field-key'
-import Spinner from './spinner'
 
 const commentsDisplayStyle = css`
   grid-column: 1 / -1;
@@ -130,8 +129,6 @@ export const ChartCard = ({
     })
     .filter((f): f is Exclude<typeof f, null> => f !== null)
 
-  if (matchesWithSelectedStat.length)
-    console.log(fieldKey, matchesWithSelectedStat[0].matchingStat)
   const dataPoints = matchesWithSelectedStat.map(s => s.matchingStat.avg)
 
   const hoveredMatchKey =

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -119,8 +119,6 @@ export const ChartCard = ({
     return matchesAutoFieldName || matchesTeleopFieldName
   })?.name
 
-  console.log(fullFieldName)
-
   const matchesWithSelectedStat = (matchesStats || [])
     .map(({ matchKey, stats }) => {
       const matchingStat = stats.find(f => f.name === fullFieldName)

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -23,6 +23,7 @@ import { getMatchTeamReports } from '@/api/report/get-match-team-reports'
 import { CommentCard } from './comment-card'
 import { cleanFieldName } from '@/utils/clean-field-name'
 import { getFieldKey } from '@/utils/get-field-key'
+import Spinner from './spinner'
 
 const commentsDisplayStyle = css`
   grid-column: 1 / -1;
@@ -90,40 +91,47 @@ export const ChartCard = ({
   schema,
 }: ChartCardProps) => {
   const firstField = schema.schema.find(f => !f.hide) as StatDescription
-  const [fieldKey, setFieldName] = useQueryState(
-    'stat',
-    getFieldKey(firstField),
-  )
+  const [fieldKey, setFieldKey] = useQueryState('stat', getFieldKey(firstField))
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
-  const matchesStats =
-    usePromise(
-      () =>
-        CancellablePromise.all(
-          teamMatches.sort(compareMatches).map(async match => ({
-            matchKey: match.key,
-            stats: await getMatchTeamStats(eventKey, match.key, team)
-              .then(s => s.summary || [])
-              .catch(() => []),
-          })),
-        ),
-      [team, teamMatches, eventKey],
-    ) || []
+  const matchesStats = usePromise(
+    () =>
+      CancellablePromise.all(
+        teamMatches.sort(compareMatches).map(async match => ({
+          matchKey: match.key,
+          stats: await getMatchTeamStats(eventKey, match.key, team)
+            .then(s => s.summary || [])
+            .catch(() => []),
+        })),
+      ),
+    [team, teamMatches, eventKey],
+  )
 
   useEffect(() => setSelectedIndex(null), [fieldKey])
 
-  const matchesWithSelectedStat = matchesStats
+  const fullFieldName = schema.schema.find(field => {
+    if (field.hide) return false
+    const matchesAutoFieldName =
+      getFieldKey({ name: field.name, period: 'auto' }) === fieldKey
+    const matchesTeleopFieldName =
+      getFieldKey({ name: field.name, period: 'teleop' }) === fieldKey
+    if (field.name.includes('auto')) return matchesAutoFieldName
+    if (field.name.includes('teleop')) return matchesTeleopFieldName
+
+    return matchesAutoFieldName || matchesTeleopFieldName
+  })?.name
+
+  console.log(fullFieldName)
+
+  const matchesWithSelectedStat = (matchesStats || [])
     .map(({ matchKey, stats }) => {
-      const matchingStat = stats.find(
-        f =>
-          // TODO: This assumes that a field only appears in auto or teleop, not both
-          getFieldKey({ name: f.name, period: 'teleop' }) === fieldKey ||
-          getFieldKey({ name: f.name, period: 'auto' }) === fieldKey,
-      )
+      const matchingStat = stats.find(f => f.name === fullFieldName)
       if (matchingStat) return { matchKey, matchingStat }
       return null
     })
     .filter((f): f is Exclude<typeof f, null> => f !== null)
 
+  if (matchesWithSelectedStat.length)
+    console.log(fieldKey, matchesWithSelectedStat[0].matchingStat)
   const dataPoints = matchesWithSelectedStat.map(s => s.matchingStat.avg)
 
   const hoveredMatchKey =
@@ -155,12 +163,14 @@ export const ChartCard = ({
           getKey={getFieldKey}
           getText={s => cleanFieldName(s.name)}
           getGroup={s => (s.period === 'auto' ? 'Auto' : 'Teleop')}
-          onChange={s => setFieldName(getFieldKey(s))}
+          onChange={s => setFieldKey(getFieldKey(s))}
           value={matchingSchemaStat}
         />
         <div class={detailsStyle}>
           {noData ? (
-            <p>No Data</p>
+            matchesStats ? (
+              <p>No Data</p>
+            ) : null
           ) : selectedIndex === null ? (
             isBooleanStat ? (
               <p>{formatPercent(average(dataPoints))}</p>


### PR DESCRIPTION
https://fix-graphs-matching--peregrine.netlify.com/events/2020orore/analysis

Sort by different columns (including columns duplicated between auto and teleop) and go to teams, make sure that it is not getting the auto stat for the teleop stat, and reverse of that. Also make sure that field names without "auto" or "teleop" are working correctly