### PR TITLE
Fix wonky match cards

### DIFF
--- a/src/components/match-card.tsx
+++ b/src/components/match-card.tsx
@@ -56,6 +56,7 @@ const matchNumStyle = css`
 `
 
 const allianceStyle = css`
+  white-space: nowrap;
   grid-column: 3;
   align-self: stretch;
   margin-left: 0.3rem;


### PR DESCRIPTION
I was seeing this weird layout for the match cards specifically on the match page on my phone:

![image](https://user-images.githubusercontent.com/13206945/75638513-10739180-5be1-11ea-9ee8-9c71bd4aef31.png)

Now it is fixed

https://fix-wonky-match-cards--peregrine.netlify.com/events/2020wasno/matches/qm1