### PR TITLE
Remove double underline

### DIFF
--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -267,7 +267,6 @@ const tableRowStyle = css`
 
   & td {
     padding: 0.8rem 0.6rem;
-    ${borderBottomOnly};
   }
 
   & th:last-of-type {


### PR DESCRIPTION
This PR fixes the bug. #823 also fixes the bug. If this PR works on iOS, I'd like to merge both fixes. If this PR doesn't work on iOS, only #823 should be merged

---

https://peregrine.ga/events/2020orore/matches/qm2

On small screens, there is a double border on the bottom of the cells in the rank column

![screenshot](https://user-images.githubusercontent.com/13206945/75654165-f7380880-5c13-11ea-9487-aea2d9e36e43.png)

This fixes that

https://fix-double-border--peregrine.netlify.com/events/2020orore/matches/qm2

Verify:
- Double border is no longer shown on the match analysis
- All tables across the site have the correct borders, even when scrolling (Analysis Table, Users Table)