### PR TITLE
Remove double underline: Alternate fix

### DIFF
--- a/src/components/analysis-table.tsx
+++ b/src/components/analysis-table.tsx
@@ -211,15 +211,12 @@ const AnalysisTable = ({
   }
 
   const rankCellStyle = css`
-    display: grid;
     white-space: nowrap;
-    justify-content: center;
-    align-items: center;
-    grid-gap: 0.25rem;
+    text-align: center;
     min-width: 5.5rem;
 
     & :not(:first-child) {
-      grid-column: 2;
+      padding-left: 0.25rem;
       font-size: 0.7rem;
       color: ${textGrey};
     }


### PR DESCRIPTION
This PR fixes the bug. #822 also fixes the bug. If #822 works on iOS, I'd like to merge both fixes. If #822 doesn't work on iOS, only this fix should be merged

---

https://peregrine.ga/events/2020orore/matches/qm2

On small screens, there is a double border on the bottom of the cells in the rank column

![screenshot](https://user-images.githubusercontent.com/13206945/75654165-f7380880-5c13-11ea-9487-aea2d9e36e43.png)

This fixes that

https://fix-double-border-alt--peregrine.netlify.com/events/2020orore/matches/qm2

Verify:
- Double border is no longer shown on the match analysis
- All tables across the site have the correct borders, even when scrolling (Analysis Table, Users Table)