### PR TITLE
Add event team matches route

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -28,6 +28,10 @@ const routes = [
     component: () => import('./routes/event-team-comments'),
   },
   {
+    path: '/events/:eventKey/teams/:teamNum/matches',
+    component: () => import('./routes/event-team-matches'),
+  },
+  {
     path: '/users',
     component: () => import('./routes/users'),
   },

--- a/src/routes/event-team-matches.tsx
+++ b/src/routes/event-team-matches.tsx
@@ -1,0 +1,42 @@
+import Page from '@/components/page'
+import { h } from 'preact'
+import { useEventInfo } from '@/cache/event-info/use'
+import { useEventMatches } from '@/cache/event-matches/use'
+import { EventMatches } from '@/components/event-matches'
+import Spinner from '@/components/spinner'
+import { css } from 'linaria'
+
+interface Props {
+  eventKey: string
+  teamNum: string
+}
+
+const eventTeamMatchesStyle = css`
+  display: grid;
+  grid-template-columns: 23rem;
+  max-width: 100%;
+  justify-content: center;
+  margin: 1rem;
+  grid-gap: 1rem;
+`
+
+const EventTeamMatches = ({ eventKey, teamNum }: Props) => {
+  const event = useEventInfo(eventKey)
+  const eventName = event?.name || eventKey
+  const matches = useEventMatches(eventKey, 'frc' + teamNum)
+  return (
+    <Page
+      name={`Matches: ${teamNum} @ ${eventName}`}
+      back={`/events/${eventKey}/teams/${teamNum}`}
+      class={eventTeamMatchesStyle}
+    >
+      {matches ? (
+        <EventMatches matches={matches} eventKey={eventKey} />
+      ) : (
+        <Spinner />
+      )}
+    </Page>
+  )
+}
+
+export default EventTeamMatches

--- a/src/routes/event-team.tsx
+++ b/src/routes/event-team.tsx
@@ -204,6 +204,9 @@ const EventTeam = ({ eventKey, teamNum }: Props) => {
       <Button href={`/events/${eventKey}/teams/${teamNum}/comments`}>
         View all comments
       </Button>
+      <Button href={`/events/${eventKey}/teams/${teamNum}/matches`}>
+        View Matches
+      </Button>
       {teamMatches && schema && (
         <ChartCard
           team={'frc' + teamNum}


### PR DESCRIPTION
https://event-team-matches-route--peregrine.netlify.com/events/2020orore/teams/2411

Click "View Matches"

Make sure match searching only applies to matches that include that team. So if you search for another team it should show matches that both teams are in