### PR TITLE
Ignore error if team info endpoint returns 404

### DIFF
--- a/src/routes/event-team.tsx
+++ b/src/routes/event-team.tsx
@@ -146,7 +146,7 @@ type TeamLocation =
 const EventTeam = ({ eventKey, teamNum }: Props) => {
   const eventInfo = useEventInfo(eventKey)
   const eventTeamInfo = usePromise(
-    () => getEventTeamInfo(eventKey, 'frc' + teamNum),
+    () => getEventTeamInfo(eventKey, 'frc' + teamNum).catch(() => undefined),
     [eventKey, teamNum],
   )
   const schema = useSchema(eventInfo?.schemaId)
@@ -176,14 +176,14 @@ const EventTeam = ({ eventKey, teamNum }: Props) => {
           {
             title: 'Rank',
             icon: sortAscending,
-            action: eventTeamInfo ? eventTeamInfo.rank : '',
+            action: eventTeamInfo ? eventTeamInfo.rank : '?',
           },
           {
             title: 'Ranking Score',
             icon: history,
             action: eventTeamInfo?.rankingScore
               ? round(eventTeamInfo.rankingScore)
-              : '',
+              : '?',
           },
           teamLocation && {
             title: formatTeamLocation(teamLocation, eventKey),


### PR DESCRIPTION
Dev/Prod:
![screenshot](https://user-images.githubusercontent.com/13206945/75948941-9ef24800-5e59-11ea-86b6-bd4a01fa4a6b.png)
https://dev.peregrine.ga/events/2020waspo/teams/2147
- Ugly 404 bar
- Ugly Ranking Points is right up against edge

This branch:
![screenshot](https://user-images.githubusercontent.com/13206945/75948971-b92c2600-5e59-11ea-9a00-befc50a35856.png)
https://handle-team-404--peregrine.netlify.com/events/2020waspo/teams/2147
- ? is a lot nicer
- No 404 bar because error is caught
