### PR TITLE
Add geolocation button

### DIFF
--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -58,7 +58,13 @@ const Home = () => {
       <div class={filterStyle}>
         <Dropdown options={years} onChange={setYear} value={year} />
         <TextInput onInput={setQuery} label="Search for Events" />
-        {prompt && <IconButton icon={mdiCrosshairsGps} onClick={prompt} />}
+        {prompt && (
+          <IconButton
+            icon={mdiCrosshairsGps}
+            onClick={prompt}
+            title="Use geolocation for sorting"
+          />
+        )}
       </div>
 
       {events ? (

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -12,6 +12,8 @@ import { Dropdown } from '@/components/dropdown'
 import { useQueryState } from '@/utils/use-query-state'
 import { UnstyledList } from '@/components/unstyled-list'
 import { useYears } from '@/utils/use-years'
+import IconButton from '@/components/icon-button'
+import { mdiCrosshairsGps } from '@mdi/js'
 
 const homeStyle = css`
   display: grid;
@@ -27,15 +29,23 @@ const matchListStyle = css`
 `
 
 const filterStyle = css`
-  display: grid;
-  grid-template-columns: min-content 1fr;
-  grid-gap: 1rem;
+  display: flex;
+  align-items: center;
+  margin: -0.5rem;
+
+  & > * {
+    margin: 0.5rem;
+  }
+
+  & > :nth-child(2) {
+    flex-grow: 1;
+  }
 `
 
 const now = new Date()
 const currentYear = now.getFullYear()
 const Home = () => {
-  const location = useGeoLocation()
+  const [location, prompt] = useGeoLocation()
   const [query, setQuery] = useState('')
   const lowerCaseQuery = query.toLowerCase()
   const [yearVal, setYear] = useQueryState('year', currentYear)
@@ -48,6 +58,7 @@ const Home = () => {
       <div class={filterStyle}>
         <Dropdown options={years} onChange={setYear} value={year} />
         <TextInput onInput={setQuery} label="Search for Events" />
+        {prompt && <IconButton icon={mdiCrosshairsGps} onClick={prompt} />}
       </div>
 
       {events ? (

--- a/src/utils/use-geo-location.ts
+++ b/src/utils/use-geo-location.ts
@@ -33,6 +33,20 @@ const getGeoLocation = () =>
     ),
   )
 
+const getLocation = async (): Promise<LatLong> => {
+  if (navigator.permissions) {
+    const geoPermission = await navigator.permissions.query({
+      name: 'geolocation',
+    })
+    if (geoPermission.state === 'granted') return getGeoLocation()
+  } else {
+    // In browsers that don't support navigator.permissions (safari)
+    // ask for location right away
+    return getGeoLocation()
+  }
+  return getIpLocation()
+}
+
 const locationKey = 'geolocation'
 
 const getLocationFromLocalStorage = () => {
@@ -48,7 +62,7 @@ export const useGeoLocation = () => {
     navigator.permissions === undefined,
   )
   useEffect(() => {
-    const locationPromise = getGeoLocation()
+    const locationPromise = getLocation()
     locationPromise.then((loc) =>
       localStorage.setItem(locationKey, JSON.stringify(loc)),
     )

--- a/src/utils/use-geo-location.ts
+++ b/src/utils/use-geo-location.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'preact/hooks'
-import { EMPTY_PROMISE, noop } from './empty-promise'
+import { EMPTY_PROMISE } from './empty-promise'
 
 const apiKey = process.env.IPDATA_API_KEY
 const apiUrl =


### PR DESCRIPTION
Closes #890

https://add-geolocation-button--peregrine.netlify.app/

- There should be no geolocation prompt until you click the geolocation button on the homepage
- The geolocation button should not appear if you already clicked "allow" or "block"
- When you click on the geolocation button the browser should prompt for your location

In iOS and safari, we don't have the ability to know if the user has clicked "allow" or "block" so the button will always appear.