### PR TITLE
Fix browserslist

### DIFF
--- a/.babelrc.output.js
+++ b/.babelrc.output.js
@@ -1,5 +1,15 @@
 module.exports = {
-  presets: [['@babel/preset-env', { loose: true, bugfixes: true }]],
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        loose: true,
+        bugfixes: true,
+        exclude: ['transform-regenerator', 'transform-async-to-generator'],
+        debug: true,
+      },
+    ],
+  ],
   plugins: [
     // Buggy right now so not being used
     //   process.env.NODE_ENV === 'production' &&

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     ">.5% in us",
     "not ie 11",
     "not ios_saf <11.1",
-    "not edge <79"
+    "not edge <79",
+    "not android <81"
   ],
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
For some reason really old versions of android browser started getting
included in our browserslist. I don't know why.

This caused many extra transforms to be enabled, including the
regenerator transform which broke the whole site.

I manually force-disabled those bad transforms, and I also manually
disabled support for really old versions of android browser (2014)