### PR TITLE
Fix dropdown bug on event team page

### DIFF
--- a/src/routes/event-team.tsx
+++ b/src/routes/event-team.tsx
@@ -26,6 +26,7 @@ import { Falsy } from '@/type-utils'
 import { useCurrentTime } from '@/utils/use-current-time'
 import { saveTeam, useSavedTeams, removeTeam } from '@/api/save-teams'
 import IconButton from '@/components/icon-button'
+import { EventTeamInfo } from '@/api/event-team-info'
 
 const sectionStyle = css`
   font-weight: normal;
@@ -165,9 +166,6 @@ const EventTeam = ({ eventKey, teamNum }: Props) => {
   const teamMatches = useEventMatches(eventKey, 'frc' + teamNum)?.sort(
     compareMatches,
   )
-  const now = useCurrentTime()
-
-  const teamLocation = teamMatches && guessTeamLocation(teamMatches, now)
 
   const nextMatch = teamMatches && nextIncompleteMatch(teamMatches)
 
@@ -203,35 +201,10 @@ const EventTeam = ({ eventKey, teamNum }: Props) => {
           <MatchDetailsCard match={nextMatch} eventKey={eventKey} link />
         </>
       )}
-      <InfoGroupCard
-        info={[
-          {
-            title: 'Rank',
-            icon: mdiSortDescending,
-            action: eventTeamInfo ? eventTeamInfo.rank : '?',
-          },
-          {
-            title: 'Ranking Score',
-            icon: mdiHistory,
-            action: eventTeamInfo?.rankingScore
-              ? round(eventTeamInfo.rankingScore)
-              : '?',
-          },
-          teamLocation && {
-            title: formatTeamLocation(teamLocation, eventKey),
-            icon: mdiMapMarker,
-            action: teamLocation.match.time && (
-              <span
-                class={css`
-                  color: #757575;
-                  font-size: 0.75rem;
-                `}
-              >
-                {formatTimeWithoutDate(teamLocation.match.time)}
-              </span>
-            ),
-          },
-        ]}
+      <EventTeamInfoCard
+        eventKey={eventKey}
+        eventTeamInfo={eventTeamInfo}
+        teamMatches={teamMatches}
       />
       <Button href={`/events/${eventKey}/teams/${teamNum}/comments`}>
         View all comments
@@ -248,6 +221,51 @@ const EventTeam = ({ eventKey, teamNum }: Props) => {
         />
       )}
     </Page>
+  )
+}
+
+const EventTeamInfoCard = ({
+  eventTeamInfo,
+  teamMatches,
+  eventKey,
+}: {
+  eventTeamInfo?: EventTeamInfo
+  teamMatches?: ProcessedMatchInfo[]
+  eventKey: string
+}) => {
+  const now = useCurrentTime()
+  const teamLocation = teamMatches && guessTeamLocation(teamMatches, now)
+  return (
+    <InfoGroupCard
+      info={[
+        {
+          title: 'Rank',
+          icon: mdiSortDescending,
+          action: eventTeamInfo ? eventTeamInfo.rank : '?',
+        },
+        {
+          title: 'Ranking Score',
+          icon: mdiHistory,
+          action: eventTeamInfo?.rankingScore
+            ? round(eventTeamInfo.rankingScore)
+            : '?',
+        },
+        teamLocation && {
+          title: formatTeamLocation(teamLocation, eventKey),
+          icon: mdiMapMarker,
+          action: teamLocation.match.time && (
+            <span
+              class={css`
+                color: #757575;
+                font-size: 0.75rem;
+              `}
+            >
+              {formatTimeWithoutDate(teamLocation.match.time)}
+            </span>
+          ),
+        },
+      ]}
+    />
   )
 }
 


### PR DESCRIPTION
There was a bug on the event team page that was bothering me. It happens on my (android) phone, but not my computer.

On the event team page: 
<img width=400 src="https://user-images.githubusercontent.com/13206945/157179517-9643b362-10c0-4cde-9e08-12344d0d2d28.png">

The team location predictor (in the screenshot showing "Queueing for Qual 35") refreshes its status every second (because the time changed) (nothing gets re-requested over the network).

When it refreshes its status, the entire page does a re-render. Normally, this would be OK. But on Chrome on Android, dropdowns that are opened seem to close and reopen when their HTML is changed. So, if I open the stat picker dropdown on my phone, every second, the dropdown closes and reopens. It is frustrating.

This PR fixes that bug by isolating the time-dependent code (for the team location predictor) into a separate component for just the team@event info card. Now, just that one component re-renders every second (which is OK). Now since the dropdown does not re-render every second, it stays open on my phone.
