### PR TITLE
add arrow on scouting form dropdown menu

### DIFF
--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -9,6 +9,7 @@ const dropdownStyle = css`
   font-size: 0.8rem;
   color: var(--off-black);
   font-weight: bold;
+  appearance: menulist;
 
   & option {
     text-transform: none;


### PR DESCRIPTION
closes #1541 
Forces all dropdown elements to have an arrow that tells the user that the element is a dropdown.