### PR TITLE
default to the current year in year dropdowns

### DIFF
--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -47,7 +47,7 @@ const Home = () => {
   const [query, setQuery] = useState('')
   const lowerCaseQuery = query.toLowerCase()
   const years = useYears().sort().reverse()
-  const [yearVal, setYear] = useQueryState('year', years[0])
+  const [yearVal, setYear] = useQueryState('year', new Date().getFullYear())
   const year = Number(yearVal)
   const events = useEvents(year)
 

--- a/src/routes/leaderboard.tsx
+++ b/src/routes/leaderboard.tsx
@@ -43,7 +43,7 @@ const leaderboardListStyle = css`
 
 const LeaderboardList = () => {
   const years = useYears().sort().reverse()
-  const [yearVal, setYear] = useQueryState('year', years[0])
+  const [yearVal, setYear] = useQueryState('year', new Date().getFullYear())
   const year = Number(yearVal)
   const leaderboard = usePromise(async () => {
     const leaderboard = await getLeaderboard(year)


### PR DESCRIPTION
On the home and leaderboard pages, the year dropdown should default to the current year rather than the last year with events.